### PR TITLE
AnnotateUltrasound: make current file label text selectable

### DIFF
--- a/AnnotateUltrasound/AnnotateUltrasound.py
+++ b/AnnotateUltrasound/AnnotateUltrasound.py
@@ -187,6 +187,8 @@ class AnnotateUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
         uiWidget = slicer.util.loadUI(self.resourcePath('UI/AnnotateUltrasound.ui'))
         self.layout.addWidget(uiWidget)
         self.ui = slicer.util.childWidgetVariables(uiWidget)
+        self.ui.currentFileLabel.setTextInteractionFlags(qt.Qt.TextSelectableByMouse)
+
 
         # Set scene in MRML widgets. Make sure that in Qt designer the top-level qMRMLWidget's
         # "mrmlSceneChanged(vtkMRMLScene*)" signal in is connected to each MRML widget's.


### PR DESCRIPTION
Added the ability to select and copy the current file name from the UI. This small change allows users to easily copy the file name for reference, documentation, or reporting purposes.

Changes:
- Added `setTextInteractionFlags(qt.Qt.TextSelectableByMouse)` to the current file label

Testing:
- Verified that the file name can be selected and copied from the UI. See image below:

![selectable_file_name](https://github.com/user-attachments/assets/e58e39c8-ac24-4af3-9c1f-ab97d4a4fabc)
