### PR TITLE
AnnotateUltrasound: add annotations on startup for first frame

### DIFF
--- a/AnnotateUltrasound/AnnotateUltrasound.py
+++ b/AnnotateUltrasound/AnnotateUltrasound.py
@@ -399,10 +399,20 @@ class AnnotateUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
             self.ui.currentFileLabel.setText(statusText)
             self.ui.statusLabel.setText('')
             slicer.util.mainWindow().statusBar().showMessage(statusText, 3000)
+            self.logic.sequenceBrowserNode.SetSelectedItemNumber(0)
+            self.logic.updateCurrentFrame()
+            self.updateGuiFromAnnotations()
+
+            self.ui.intensitySlider.setValue(0)
 
             # Close the wait dialog
             waitDialog.close()
+
+            self.ui.progressBar.value = self.currentDicomDfIndex
+
+            self.ui.overlayVisibilityButton.setChecked(True)
         else:
+
             statusText = 'Could not find any files to load in input directory!'
             slicer.util.mainWindow().statusBar().showMessage(statusText, 3000)
             self.ui.statusLabel.setText(statusText)


### PR DESCRIPTION
Update sequence browser node to 0 on first startup load of directory and update GUI like we do on Next Sequence.