### PR TITLE
AnnotateUltrasound: fix depth guide settings not preserved when navigating to previous image

### DIFF
--- a/AnnotateUltrasound/AnnotateUltrasound.py
+++ b/AnnotateUltrasound/AnnotateUltrasound.py
@@ -571,6 +571,9 @@ class AnnotateUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
         # Create a dialog to ask the user to wait while the next sequence is loaded.
         waitDialog = self.createWaitDialog("Loading previous sequence", "Loading previous sequence...")
         
+        # Save settings
+        showDepthGuide = self._parameterNode.depthGuideVisible
+        
         savedNextDicomDfIndex = self.logic.nextDicomDfIndex
         currentDicomDfIndex = self.logic.loadPreviousSequence()
         if currentDicomDfIndex is None:
@@ -589,6 +592,9 @@ class AnnotateUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
         slicer.util.mainWindow().statusBar().showMessage(statusText, 3000)
 
         self.updateGuiFromAnnotations()
+        
+        # Restore settings
+        self._parameterNode.depthGuideVisible = showDepthGuide
 
         self.ui.intensitySlider.setValue(0)
         


### PR DESCRIPTION
Fixed a bug where the depth guide settings were not preserved when navigating to the previous image. The settings were being preserved when going to the next image, but not when going back.

Changes:
- Added code to save and restore depth guide settings in the `onPreviousButton` method
- This matches the behavior already implemented in the `onNextButton` method
