### PR TITLE
Add developer‑mode auto‑overlay for AnonymizeUltrasound

### DIFF
--- a/AnonymizeUltrasound/Resources/UI/AnonymizeUltrasound.ui
+++ b/AnonymizeUltrasound/Resources/UI/AnonymizeUltrasound.ui
@@ -292,6 +292,16 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="autoOverlayCheckBox">
+        <property name="toolTip">
+        <string>If checked, show the automatic (red) overlay mask.</string>
+        </property>
+        <property name="text">
+        <string>Show automatic overlay</string>
+        </property>
+        </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="skipSingleframeCheckBox">
         <property name="text">
          <string>Skip single-frame input DICOM files</string>


### PR DESCRIPTION
Displays the AI‑predicted fan mask as a **red overlay** when Slicer is in *Developer mode*. Keeps the feature hidden from regular users while giving developers an easy way to inspect raw model output. No changes to anonymization logic or export workflow.

![anonymize-ultrasound-auto-overlay](https://github.com/user-attachments/assets/3421bbb6-19c9-4586-8e7f-64bff8fca1f0)
