### PR TITLE
3-point fan (cardiac-probe) support 

### DIFF
--- a/AnonymizeUltrasound/AnonymizeUltrasound.py
+++ b/AnonymizeUltrasound/AnonymizeUltrasound.py
@@ -594,13 +594,13 @@ class AnonymizeUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             return
         
         # determine if three-point fan mode is active
-        three_point = self.ui.threePointFanCheckBox.checked
+        threePointFanModeEnabled = self.ui.threePointFanCheckBox.checked
 
         # Automatic mask via AI only when NOT in three-point fan mode
         # TODO: Support for three-point fan mode auto mask
         autoMaskSuccessful = False
         if self.ui.autoMaskCheckBox.checked:
-            if three_point:
+            if threePointFanModeEnabled:
                 logging.info("Auto mask not applied because in three-point fan mode")
             else:
                 # Get the mask control points
@@ -667,11 +667,11 @@ class AnonymizeUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             logging.error("Markups node not found")
             return
 
-        three_point = self.ui.threePointFanCheckBox.checked
-        required = 3 if three_point else 4
+        threePointFanModeEnabled = self.ui.threePointFanCheckBox.checked
+        required = 3 if threePointFanModeEnabled else 4
         count = markupsNode.GetNumberOfControlPoints()
         if count == required:
-            self.logic.updateMaskVolume(three_point=three_point)
+            self.logic.updateMaskVolume(three_point=threePointFanModeEnabled)
             maskContourVolumeNode = self._parameterNode.overlayVolume
             if maskContourVolumeNode:
                 sliceCompositeNode = slicer.app.layoutManager().sliceWidget("Red").mrmlSliceCompositeNode()
@@ -687,12 +687,12 @@ class AnonymizeUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
 
         markupsNode = self._parameterNode.maskMarkups
         # determine required points based on 3-point fan mode
-        three_point = self.ui.threePointFanCheckBox.checked
+        threePointFanModeEnabled = self.ui.threePointFanCheckBox.checked
         count = markupsNode.GetNumberOfControlPoints()
-        required = 3 if three_point else 4
+        required = 3 if threePointFanModeEnabled else 4
         if count == required:
             # finalize mask placement
-            self.logic.updateMaskVolume(three_point=three_point)
+            self.logic.updateMaskVolume(three_point=threePointFanModeEnabled)
             self.logic.showMaskContour()
         else:
             slicer.util.setSliceViewerLayers(foreground=None)
@@ -703,11 +703,11 @@ class AnonymizeUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         if not markupsNode:
             logging.error("Markups node not found")
             return
-        three_point = self.ui.threePointFanCheckBox.checked
+        threePointFanModeEnabled = self.ui.threePointFanCheckBox.checked
         count = markupsNode.GetNumberOfControlPoints()
-        required = 3 if three_point else 4
+        required = 3 if threePointFanModeEnabled else 4
         if count == required:
-            self.logic.updateMaskVolume(three_point=three_point)
+            self.logic.updateMaskVolume(three_point=threePointFanModeEnabled)
             self.logic.showMaskContour()
             self.ui.defineMaskButton.checked = False
             self._parameterNode.status = AnonymizerStatus.LANDMARKS_PLACED
@@ -759,8 +759,8 @@ class AnonymizeUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
                 return
         
         # Mask images to erase the unwanted parts
-        three_point_bool = self.ui.threePointFanCheckBox.checked
-        self.logic.maskSequence(three_point=three_point_bool)
+        threePointFanModeEnabled = self.ui.threePointFanCheckBox.checked
+        self.logic.maskSequence(three_point=threePointFanModeEnabled)
         
         # Set up output directory and filename
         

--- a/AnonymizeUltrasound/AnonymizeUltrasound.py
+++ b/AnonymizeUltrasound/AnonymizeUltrasound.py
@@ -135,7 +135,6 @@ class AnonymizeUltrasoundParameterNode:
     patientId: str = ""                                    # Currently loaded patient
     studyInstanceUid: str = ""                             # Currently loaded study
     seriesInstanceUid: str = ""                            # Currently loaded series
-    threePointFanMode: bool = False                        # Allow 3-point fan mask when enabled
 
 #
 # AnonymizeUltrasoundWidget
@@ -156,7 +155,7 @@ class AnonymizeUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     HASH_PATIENT_ID_SETTING = "AnonymizeUltrasound/HashPatientId"
     FILENAME_PREFIX_SETTING = "AnonymizeUltrasound/FilenamePrefix"
     LABELS_PATH_SETTING = "AnonymizeUltrasound/LabelsPath"
-    THREE_POINT_FAN_SETTING = "AnonymizeUltrasound/ThreePointFanMode"
+    THREE_POINT_FAN_SETTING = "AnonymizeUltrasound/ThreePointFan"
 
     def __init__(self, parent=None) -> None:
         """Called when the user opens the module the first time and the widget is initialized."""

--- a/AnonymizeUltrasound/Resources/UI/AnonymizeUltrasound.ui
+++ b/AnonymizeUltrasound/Resources/UI/AnonymizeUltrasound.ui
@@ -326,6 +326,19 @@
        </widget>
       </item>
       <item>
+        <widget class="QCheckBox" name="threePointFanCheckBox">
+        <property name="toolTip">
+          <string>Allow defining a fan mask with 1 top point and 2 bottom points</string>
+        </property>
+        <property name="text">
+          <string>Enable 3-Point Fan Mask</string>
+        </property>
+        <property name="SlicerParameterName">
+          <string>threePointFanMode</string>
+        </property>
+        </widget>
+      </item>
+      <item>
        <layout class="QVBoxLayout" name="verticalLayout_3">
         <item>
          <widget class="QLabel" name="label_4">

--- a/AnonymizeUltrasound/Resources/UI/AnonymizeUltrasound.ui
+++ b/AnonymizeUltrasound/Resources/UI/AnonymizeUltrasound.ui
@@ -333,9 +333,6 @@
         <property name="text">
           <string>Enable 3-Point Fan Mask</string>
         </property>
-        <property name="SlicerParameterName">
-          <string>threePointFanMode</string>
-        </property>
         </widget>
       </item>
       <item>


### PR DESCRIPTION
Added support for cardiac probe. Setting can be toggled via checkbox and persists across clips. Annotation config remains the same, because I just use very similar mask logic from the default curvilinear— just set radius1 to 0, so no patch necessary for the old clips. 

Currently no support for auto-mask when 3-points setting is enabled...