### PR TITLE
AttributeError when accessing PatientID when `Continued Progress` is enabled

### DIFF
--- a/AnonymizeUltrasound/AnonymizeUltrasound.py
+++ b/AnonymizeUltrasound/AnonymizeUltrasound.py
@@ -480,7 +480,12 @@ class AnonymizeUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     
     def onNextButton(self) -> None:
         logging.info("Next button clicked")
-        
+
+        # If continue progress is checked and nextDicomDfIndex is None, there is nothing more to load
+        if self.logic.nextDicomDfIndex is None and self.ui.continueProgressCheckBox.checked:
+            self.ui.statusLabel.text = "All files from input folder have been processed to output folder. No more files to load."
+            return
+
         # Remove observers for the mask markups node, because loading a new series will reset the scene and createa a new markups node
         
         maskMarkupsNode = self._parameterNode.maskMarkups


### PR DESCRIPTION

**[Issue]**
When the continued progress setting is enabled and all DICOM files have been processed, clicking on the "Load Next" button results in an AttributeError on `self.logic.currentDicomDataset` because the Dicom dataset is not loaded.

```sh
SlicerUltrasound/AnonymizeUltrasound/AnonymizeUltrasound.py", line 529, in onNextButton
    patientID = self.logic.currentDicomDataset.PatientID
AttributeError: 'NoneType' object has no attribute 'PatientID'
```

**[Solution]**
Exit early and log status to user if `onNextButton` function is called but all files have been processed and the `Continued Progress` setting is enabled. Currently this use case results in `self.logic.nextDicomDfIndex` getting set to None which has a side effect of not loading the DICOM files into the session. A future refactor should consider looking into ways of storing this state to avoid side effects.

[Test]
0. Load input and output folder with identical set of DICOM files.
1. Enable "Continued Progress"
2. Click "Import DICOM folder"
3. Click "Load next"

You should see a status indicating all DICOM files have been processed.