### PR TITLE
Add Scanner Mask Caching System

### DIFF
--- a/AnonymizeUltrasound/Resources/UI/AnonymizeUltrasound.ui
+++ b/AnonymizeUltrasound/Resources/UI/AnonymizeUltrasound.ui
@@ -279,6 +279,19 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
+       <widget class="QCheckBox" name="enableMaskCacheCheckBox">
+        <property name="toolTip">
+         <string>If checked, cached mask will be used for DICOM transducer.</string>
+        </property>
+        <property name="text">
+         <string>Use cached mask</string>
+        </property>
+        <property name="invertThreshold" stdset="0">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="autoMaskCheckBox">
         <property name="toolTip">
          <string>If checked, values above threshold are set to 0. If unchecked, values below are set to 0.</string>

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -1,0 +1,63 @@
+# Debugging
+
+## VS Code
+
+1. Setup VS Code Debugger
+Create a .vscode/launch.json file:
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        
+        {
+            "name": "Python: Remote Attach",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "port": 5678,
+                "host": "localhost"
+            },
+            "justMyCode": false,
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "${workspaceFolder}"
+                }
+            ]
+        }
+    ]
+}
+```
+
+Create a .vscode/settings.json file:
+```json
+{
+    "python.defaultInterpreterPath": "/Applications/Slicer.app/Contents/bin/PythonSlicer",
+    "python.terminal.activateEnvironment": false,
+    "python.autoComplete.extraPaths": [
+        "/Applications/Slicer.app/Contents/lib/Slicer-5.8/qt-scripted-modules",
+        "/Applications/Slicer.app/Contents/lib/Slicer-5.8/qt-loadable-modules",
+        "/Applications/Slicer.app/Contents/lib/Python/lib/python3.9/site-packages",
+    ],
+    "python.analysis.extraPaths": [
+        "/Applications/Slicer.app/Contents/lib/Slicer-5.8/qt-scripted-modules",
+        "/Applications/Slicer.app/Contents/lib/Slicer-5.8/qt-loadable-modules",
+        "/Applications/Slicer.app/Contents/lib/Python/lib/python3.9/site-packages",
+    ]
+}
+```
+
+2. Slicer Python Console
+```python
+import debugpy
+debugpy.listen(("localhost", 5678))
+print("Waiting for debugger attach...")
+debugpy.wait_for_client()
+print("Debugger attached!")
+debugpy.breakpoint()
+```
+
+3. Run and Debug
+Open `Run and Debug` view in VS Code, select `Python: Remote Attach` and click `Run`
+
+4. Add breakpoints


### PR DESCRIPTION
This PR introduces a caching mechanism for scanner masks based on transducer models.

**Changes:**

- Transducer Model Detection: Extract and normalize transducer model from DICOM `TransducerType` field
- Mask Caching System: Store mask configurations (control points and parameters) per transducer model
- Automatic Mask Application: Apply cached masks when loading scans from previously seen transducers
- Cache Management: Save current mask to cache when exporting scans
- Add "Use cached mask" checkbox in settings panel to enable/disable the caching feature. Disabling the setting will also clear the cache.
- Remove existing session caching of mask points to simplify code and avoid feature duplication.

**Workflow Integration:**

- Cache lookup occurs automatically when loading new DICOM sequences
- Masks are saved to cache during export process
- Graceful fallback to manual mask definition if cached mask does not exist

**Usage:**

1. Enable "Use cached mask" checkbox in settings
2. Define mask for a scan from a specific transducer model
3. Export the scan
4. Load another scan from the same transducer model
5. Cached mask is automatically applied if available