### PR TITLE
Alpha blend overlay volume instead of Add

### DIFF
--- a/AnnotateUltrasound/AnnotateUltrasound.py
+++ b/AnnotateUltrasound/AnnotateUltrasound.py
@@ -978,7 +978,7 @@ class AnnotateUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
             redSliceCompositeNode = slicer.app.layoutManager().sliceWidget("Red").sliceLogic().GetSliceCompositeNode()
             redSliceCompositeNode.SetForegroundVolumeID(self._parameterNode.overlayVolume.GetID())
             redSliceCompositeNode.SetForegroundOpacity(0.12)
-            redSliceCompositeNode.SetCompositing(2)
+            redSliceCompositeNode.SetCompositing(slicer.vtkMRMLSliceCompositeNode.Alpha)
             displayNode = self._parameterNode.overlayVolume.GetDisplayNode()
             displayNode.SetWindow(255)
             displayNode.SetLevel(127)
@@ -1037,7 +1037,7 @@ class AnnotateUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
 
         sliceCompositeNode = slicer.app.layoutManager().sliceWidget("Red").mrmlSliceCompositeNode()
         self.compositingModeExit = sliceCompositeNode.GetCompositing()
-        sliceCompositeNode.SetCompositing(2)
+        sliceCompositeNode.SetCompositing(slicer.vtkMRMLSliceCompositeNode.Alpha)
 
         # Load labels for annotations
         
@@ -1782,7 +1782,7 @@ class AnnotateUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
         redSliceCompositeNode = slicer.app.layoutManager().sliceWidget("Red").sliceLogic().GetSliceCompositeNode()
         redSliceCompositeNode.SetForegroundVolumeID(overlayVolume.GetID())
         redSliceCompositeNode.SetForegroundOpacity(0.12)
-        redSliceCompositeNode.SetCompositing(2)
+        redSliceCompositeNode.SetCompositing(slicer.vtkMRMLSliceCompositeNode.Alpha)
         displayNode = overlayVolume.GetDisplayNode()
         displayNode.SetWindow(255)
         displayNode.SetLevel(127)


### PR DESCRIPTION
Slicer 5.9.0 Preview shows the background as black if we use Add instead of Alpha in SetCompositing(), while Slicer 5.8.1 is fine with Add. I am not sure why this is yet.