### PR TITLE
fixed faulty logging command

### DIFF
--- a/AnonymizeUltrasound/AnonymizeUltrasound.py
+++ b/AnonymizeUltrasound/AnonymizeUltrasound.py
@@ -972,7 +972,7 @@ class AnonymizeUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin)
                     transducer_model = self.getTransducerModel(dicom_ds.TransducerType) if 'TransducerType' in dicom_ds else 'unknown'
 
                     if transducer_model == 'unknown':
-                        logging.warning(f"Unknown transducer type in file {file_path}: {dicom_ds.TransducerType}")
+                        logging.warning(f"Unknown transducer type in file {file_path}")
 
                     if patient_id is None:
                         logging.warning(f"Patient ID missing in file {file_path}")


### PR DESCRIPTION
Fixed error where the dicom import failed

The bug was that when the field TransducerType is missing from the dicom_ds, the code correctly gracefully handles this by not accessing hte field and then just setting tranducer_modle to 'unknown'. However, the logging command still tries to access the dicom_ds.TransducerType, which does not exist. This causes the updateDicomDf to raise and catch an attribute error, causing that file to be skipped.

Fix: remove access to TranducerType in logging statement