### PR TITLE
Fix common module loading error

### DIFF
--- a/AnonymizeUltrasound/CMakeLists.txt
+++ b/AnonymizeUltrasound/CMakeLists.txt
@@ -4,6 +4,8 @@ set(MODULE_NAME AnonymizeUltrasound)
 #-----------------------------------------------------------------------------
 set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}.py
+  common/__init__.py
+  common/dicom_file_manager.py
   )
 
 set(MODULE_PYTHON_RESOURCES


### PR DESCRIPTION
**[Issue]**
When the AnonymizeUltrasound extension is installed in Slicer, the Python module loading mechanism cannot find the common package.

When Slicer loads extensions, it adds the extension directory to the Python path, but it doesn't automatically make subdirectories available as importable modules. The common directory exists but isn't being recognized as a Python package in the Slicer environment.

**[Solution]**
Update the AnonymizeUltrasound/CMakeLists.txt file to include the common directory