### PR TITLE
Losing keyboard shortcuts on Save and Load Next, Next unlabelled

### DIFF
--- a/AnnotateUltrasound/AnnotateUltrasound.py
+++ b/AnnotateUltrasound/AnnotateUltrasound.py
@@ -968,8 +968,6 @@ class AnnotateUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
         success = self.saveAnnotations()
         if success:
             self.onNextButton()
-            # After loading next, restore focus and shortcuts with a slight delay
-            self.refocusAndRestoreShortcuts()
         else:
             # Error message already shown by saveAnnotations, don't proceed to next
             return
@@ -1196,7 +1194,6 @@ class AnnotateUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
 
         self.logic.nextDicomDfIndex = nextUnlabeledIndex
         self.onNextButton()
-        self.refocusAndRestoreShortcuts()
 
     def findNextUnlabeledScan(self):
         """


### PR DESCRIPTION
We were doing refocusAndRestoreShortcuts() twice, and losing them due to a race.