### PR TITLE
Cleaup Annotate dataflow

### DIFF
--- a/AnnotateUltrasound/Testing/Python/AnnotateUltrasoundLogicTest.py
+++ b/AnnotateUltrasound/Testing/Python/AnnotateUltrasoundLogicTest.py
@@ -210,8 +210,9 @@ class AnnotateUltrasoundLogicTest(ScriptedLoadableModuleTest):
 
                 # Test updating current frame
                 logic.annotations = loaded_annotations
-                if hasattr(logic, 'updateCurrentFrame'):
-                    logic.updateCurrentFrame()
+                if hasattr(logic, 'syncMarkupsToAnnotations'):
+                    logic.syncMarkupsToAnnotations()
+                    logic.refreshDisplay(updateOverlay=True, updateGui=True)
 
                 # Verify annotations are preserved
                 self.assertIsNotNone(logic.annotations)
@@ -326,8 +327,53 @@ def runTest():
     """
     Run the tests.
     """
-    test = AnnotateUltrasoundLogicTest()
-    test.runTest()
+    import unittest
+
+    # Create a test suite
+    suite = unittest.TestSuite()
+
+    # Create test instance
+    test_instance = AnnotateUltrasoundLogicTest()
+
+    # Add all test methods to the suite
+    test_methods = [method for method in dir(test_instance) if method.startswith('test_')]
+    for method_name in test_methods:
+        suite.addTest(AnnotateUltrasoundLogicTest(method_name))
+
+    # Run the tests with a test runner
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+
+    # Print summary
+    print(f"\n=== Test Summary ===")
+    print(f"Tests run: {result.testsRun}")
+    print(f"Failures: {len(result.failures)}")
+    print(f"Errors: {len(result.errors)}")
+
+    if result.failures:
+        print(f"\n=== Failures ===")
+        for test, traceback in result.failures:
+            print(f"FAIL: {test}")
+            print(traceback)
+
+    if result.errors:
+        print(f"\n=== Errors ===")
+        for test, traceback in result.errors:
+            print(f"ERROR: {test}")
+            print(traceback)
+
+    # Return success/failure
+    return len(result.failures) == 0 and len(result.errors) == 0
 
 if __name__ == '__main__':
-    runTest()
+    success = runTest()
+    if success:
+        print("✅ All logic tests completed successfully!")
+    else:
+        print("❌ Some logic tests failed!")
+
+    # Exit Slicer after test completion
+    print("Tests complete. Exiting Slicer...")
+    slicer.util.quit()
+
+    exit(0 if success else 1)

--- a/AnnotateUltrasound/Testing/Python/test_dicom_loading.py
+++ b/AnnotateUltrasound/Testing/Python/test_dicom_loading.py
@@ -64,12 +64,13 @@ class DicomLoadingTest:
             self.test_annotation_saving()
 
             print("✅ All DICOM loading tests passed!")
+            return True
 
         except Exception as e:
             print(f"❌ DICOM loading test failed: {e}")
             import traceback
             traceback.print_exc()
-            raise
+            return False
         finally:
             self.tearDown()
 
@@ -285,16 +286,21 @@ class DicomLoadingTest:
 def runDicomTest():
     """Run the DICOM loading test."""
     test = DicomLoadingTest()
-    test.runTest()
+    success = test.runTest()
 
-    # Add a small delay to ensure all output is printed
-    import time
-    time.sleep(1)
+    # Print final result
+    if success:
+        print("✅ All DICOM loading tests completed successfully!")
+    else:
+        print("❌ Some DICOM loading tests failed!")
 
-    # Quit Slicer after test completion
-    print("Test completed. Quitting Slicer...")
+    # Exit Slicer after test completion
+    print("Tests complete. Exiting Slicer...")
     slicer.util.quit()
+
+    return success
 
 
 if __name__ == "__main__":
-    runDicomTest()
+    success = runDicomTest()
+    exit(0 if success else 1)

--- a/AnnotateUltrasound/Testing/Python/test_update_current_frame_bug.py
+++ b/AnnotateUltrasound/Testing/Python/test_update_current_frame_bug.py
@@ -139,7 +139,8 @@ def test_updateCurrentFrame_bug(test_data_dir=None):
         print("SUCCESS: Created pleura line")
 
         # Update current frame to save the annotation
-        logic.updateCurrentFrame()
+        logic.syncMarkupsToAnnotations()
+        logic.refreshDisplay(updateOverlay=True, updateGui=True)
         print("SUCCESS: Updated current frame")
 
         # Verify we have 1 pleura line
@@ -157,7 +158,8 @@ def test_updateCurrentFrame_bug(test_data_dir=None):
         print("SUCCESS: Now at frame {}".format(current_frame))
 
         # Trigger update (this should hide lines from frame 0)
-        logic.updateLineMarkups()
+        logic.syncAnnotationsToMarkups()
+        logic.refreshDisplay(updateOverlay=True, updateGui=True)
         print("SUCCESS: Updated line markups")
         frame1_visible_pleura_count = countVisiblePleuraLines(logic)
         print("Got {} visible pleura lines at frame 1".format(frame1_visible_pleura_count))
@@ -170,7 +172,8 @@ def test_updateCurrentFrame_bug(test_data_dir=None):
         print("SUCCESS: Created second pleura line")
 
         # Update current frame to save the annotation
-        logic.updateCurrentFrame()
+        logic.syncMarkupsToAnnotations()
+        logic.refreshDisplay(updateOverlay=True, updateGui=True)
         print("SUCCESS: Updated current frame")
 
         # Verify we have 1 pleura line visible at frame 1
@@ -188,7 +191,8 @@ def test_updateCurrentFrame_bug(test_data_dir=None):
         print("SUCCESS: Back to frame {}".format(current_frame))
 
         # Trigger update (this should show only frame 0 lines)
-        logic.updateLineMarkups()
+        logic.syncAnnotationsToMarkups()
+        logic.refreshDisplay(updateOverlay=True, updateGui=True)
         print("SUCCESS: Updated line markups")
 
         # Step 5: Verify only 1 pleura line is visible at frame 0 (the bug would show multiple)
@@ -223,7 +227,8 @@ def test_updateCurrentFrame_bug(test_data_dir=None):
         print("SUCCESS: Back to frame {}".format(current_frame))
 
         # Trigger update (this should show only frame 1 lines)
-        logic.updateLineMarkups()
+        logic.syncAnnotationsToMarkups()
+        logic.refreshDisplay(updateOverlay=True, updateGui=True)
         print("SUCCESS: Updated line markups")
 
         # Check visibility at frame 1
@@ -273,7 +278,8 @@ def test_updateCurrentFrame_bug(test_data_dir=None):
         print("Modified point 2: {}".format(new_point2))
 
         # Update current frame to save the changes
-        logic.updateCurrentFrame()
+        logic.syncMarkupsToAnnotations()
+        logic.refreshDisplay(updateOverlay=True, updateGui=True)
         print("SUCCESS: Updated current frame after modifying points")
 
         # Verify the points are modified
@@ -303,7 +309,8 @@ def test_updateCurrentFrame_bug(test_data_dir=None):
         print("SUCCESS: Navigated to frame {}".format(current_frame))
 
         # Trigger update
-        logic.updateLineMarkups()
+        logic.syncAnnotationsToMarkups()
+        logic.refreshDisplay(updateOverlay=True, updateGui=True)
         print("SUCCESS: Updated line markups at frame 0")
 
         # Go back to frame 1
@@ -312,7 +319,8 @@ def test_updateCurrentFrame_bug(test_data_dir=None):
         print("SUCCESS: Navigated back to frame {}".format(current_frame))
 
         # Trigger update
-        logic.updateLineMarkups()
+        logic.syncAnnotationsToMarkups()
+        logic.refreshDisplay(updateOverlay=True, updateGui=True)
         print("SUCCESS: Updated line markups at frame 1")
 
         # Check that the modified points are still there


### PR DESCRIPTION
I had messed up the dataflow and had too many functions doing similar things. This cleans it up and fixes some other
random bugs related to find next unlabelled. Also added __adjudicated_node__ to raters so that we block out the colors from raters so that when we merge adjudicator, those colors remain for the adjudicated nodes and don't confuse. It leaks some knowledge of adjudication to AnnotateUltrasound but since this code is shared, it is better than copying and it easy to understand.