### PR TITLE
Fix Resources path for fetching AnnotateUltrasound.ui

### DIFF
--- a/AdjudicateUltrasound/AdjudicateUltrasound.py
+++ b/AdjudicateUltrasound/AdjudicateUltrasound.py
@@ -145,10 +145,11 @@ class AdjudicateUltrasoundWidget(annotate.AnnotateUltrasoundWidget):
         self._userManuallySetRaterTableState = False
         self._lastUserManualCollapsedState = None  # Track the last state the user manually set
 
-    def resourcePath(self, *args):
-        import os
-        base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'AnnotateUltrasound', 'Resources'))
-        return os.path.join(base_path, *args)
+    def resourcePath(self, filename):
+        """Return the absolute path of the module ``Resources`` directory."""
+        # since we inherit from AnnotateUltrasound and use its AnnotateUltrasound.ui, we use its resource path
+        annotatePath = os.path.dirname(slicer.util.modulePath("AnnotateUltrasound"))
+        return os.path.join(annotatePath, "Resources", filename)
 
     def initializeShortcuts(self):
         super().initializeShortcuts()


### PR DESCRIPTION
When deploying from the extension manager, the path isn't ../AnnotateUltrasound, it is just Resources/UI and it shares it with AnnotateUltrasound. Modify resourcePath to explicitly request AnnotateUltrasound's path and use that Resources. This way it works for both local and released versions.