### PR TITLE
Allow line and point deletion

### DIFF
--- a/AdjudicateUltrasound/AdjudicateUltrasound.py
+++ b/AdjudicateUltrasound/AdjudicateUltrasound.py
@@ -1372,6 +1372,8 @@ class AdjudicateUltrasoundLogic(annotate.AnnotateUltrasoundLogic):
             validation = {"status": "unadjudicated"}
         node.SetAttribute("rater", rater)
         node.SetAttribute("validation", json.dumps(validation))
+        node.SetLocked(True)
+
         status = validation.get("status", "unadjudicated")
 
         # Ensure display node exists

--- a/AnnotateUltrasound/AnnotateUltrasound.py
+++ b/AnnotateUltrasound/AnnotateUltrasound.py
@@ -2723,7 +2723,7 @@ class AnnotateUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
                 self.pleuraLines.remove(caller)
             elif caller in self.bLines:
                 self.bLines.remove(caller)
-            self._freeMarkupNode(caller)
+            qt.QTimer.singleShot(0, lambda: self._freeMarkupNode(caller))
 
         parameterNode = self.getParameterNode()
         parameterNode.unsavedChanges = True

--- a/AnnotateUltrasound/AnnotateUltrasound.py
+++ b/AnnotateUltrasound/AnnotateUltrasound.py
@@ -2155,6 +2155,9 @@ class AnnotateUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
             return self.loadNextSequence()
 
     def clearScene(self):
+        if self.hasObserver(slicer.mrmlScene, slicer.mrmlScene.NodeRemovedEvent, self.onMarkupNodeRemoved):
+            self.removeObserver(slicer.mrmlScene, slicer.mrmlScene.NodeRemovedEvent, self.onMarkupNodeRemoved)
+
         self.annotations = None
         for node in self.pleuraLines:
             self.pleuraLines.remove(node)
@@ -2443,6 +2446,8 @@ class AnnotateUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
                 self.removeObserver(node, node.PointModifiedEvent, self.onPointModified)
             if self.hasObserver(node, node.PointPositionDefinedEvent, self.onPointPositionDefined):
                 self.removeObserver(node, node.PointPositionDefinedEvent, self.onPointPositionDefined)
+            if self.hasObserver(node, node.PointRemovedEvent, self.onPointRemoved):
+                self.removeObserver(node, node.PointRemovedEvent, self.onPointRemoved)
             slicer.mrmlScene.RemoveNode(node)
         self.freeMarkupNodes = []
 
@@ -2455,13 +2460,16 @@ class AnnotateUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
 
     def _freeMarkupNode(self, markupNode):
         # Handle None nodes gracefully
-        if markupNode is None:
+        if markupNode is None or markupNode.GetID() is None:
             return
 
         if self.hasObserver(markupNode, markupNode.PointModifiedEvent, self.onPointModified):
             self.removeObserver(markupNode, markupNode.PointModifiedEvent, self.onPointModified)
         if self.hasObserver(markupNode, markupNode.PointPositionDefinedEvent, self.onPointPositionDefined):
             self.removeObserver(markupNode, markupNode.PointPositionDefinedEvent, self.onPointPositionDefined)
+        if self.hasObserver(markupNode, markupNode.PointRemovedEvent, self.onPointRemoved):
+            self.removeObserver(markupNode, markupNode.PointRemovedEvent, self.onPointRemoved)
+
         markupNode.RemoveAllControlPoints()
 
         if self.useFreeList:
@@ -2497,6 +2505,8 @@ class AnnotateUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
 
         self.addObserver(markupNode, markupNode.PointModifiedEvent, self.onPointModified)
         self.addObserver(markupNode, markupNode.PointPositionDefinedEvent, self.onPointPositionDefined)
+        if not self.hasObserver(slicer.mrmlScene, slicer.mrmlScene.NodeRemovedEvent, self.onMarkupNodeRemoved):
+            self.addObserver(slicer.mrmlScene, slicer.mrmlScene.NodeRemovedEvent, self.onMarkupNodeRemoved)
 
         return markupNode
 
@@ -2516,10 +2526,15 @@ class AnnotateUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
         if not node or not slicer.mrmlScene.IsNodePresent(node):
             return
 
+        current_rater = self.getParameterNode().rater.strip().lower()
         coordinates = entry.get("line", {}).get("points", [])
         rater = entry.get("rater", "")
         color_pleura, _ = self.getColorsForRater(rater)
         node.SetAttribute("rater", rater)
+        if rater != current_rater:
+            node.SetLocked(True)
+        else:
+            node.SetLocked(False)
 
         # Ensure display node exists
         displayNode = node.GetDisplayNode()
@@ -2553,11 +2568,13 @@ class AnnotateUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
         # Update control points
         hasPointModifiedObserver = self.hasObserver(node, node.PointModifiedEvent, self.onPointModified)
         hasPointPositionDefinedObserver = self.hasObserver(node, node.PointPositionDefinedEvent, self.onPointPositionDefined)
+        hasPointRemovedObserver = self.hasObserver(node, node.PointRemovedEvent, self.onPointRemoved)
         if hasPointModifiedObserver:
             self.removeObserver(node, node.PointModifiedEvent, self.onPointModified)
         if hasPointPositionDefinedObserver:
             self.removeObserver(node, node.PointPositionDefinedEvent, self.onPointPositionDefined)
-
+        if hasPointRemovedObserver:
+            self.removeObserver(node, node.PointRemovedEvent, self.onPointRemoved)
         node.RemoveAllControlPoints()
         for pt in coordinates:
             node.AddControlPointWorld(*pt)
@@ -2567,6 +2584,8 @@ class AnnotateUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
             self.addObserver(node, node.PointModifiedEvent, self.onPointModified)
         if not hasPointPositionDefinedObserver:
             self.addObserver(node, node.PointPositionDefinedEvent, self.onPointPositionDefined)
+        if not hasPointRemovedObserver:
+            self.addObserver(node, node.PointRemovedEvent, self.onPointRemoved)
 
     def clearSceneLines(self, sync=False):
         """
@@ -2613,6 +2632,8 @@ class AnnotateUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
                 self.removeObserver(currentLine, currentLine.PointModifiedEvent, self.onPointModified)
             if self.hasObserver(currentLine, currentLine.PointPositionDefinedEvent, self.onPointPositionDefined):
                 self.removeObserver(currentLine, currentLine.PointPositionDefinedEvent, self.onPointPositionDefined)
+            if self.hasObserver(currentLine, currentLine.PointRemovedEvent, self.onPointRemoved):
+                self.removeObserver(currentLine, currentLine.PointRemovedEvent, self.onPointRemoved)
             self.pleuraLines.remove(currentLine)
             self._freeMarkupNode(currentLine)
             if sync:
@@ -2643,6 +2664,8 @@ class AnnotateUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
                 self.removeObserver(currentLine, currentLine.PointModifiedEvent, self.onPointModified)
             if self.hasObserver(currentLine, currentLine.PointPositionDefinedEvent, self.onPointPositionDefined):
                 self.removeObserver(currentLine, currentLine.PointPositionDefinedEvent, self.onPointPositionDefined)
+            if self.hasObserver(currentLine, currentLine.PointRemovedEvent, self.onPointRemoved):
+                self.removeObserver(currentLine, currentLine.PointRemovedEvent, self.onPointRemoved)
             self.bLines.remove(currentLine)
             self._freeMarkupNode(currentLine)
             if sync:
@@ -2653,12 +2676,19 @@ class AnnotateUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
 
     def onPointModified(self, caller, event):
         numControlPoints = caller.GetNumberOfControlPoints()
+        parameterNode = self.getParameterNode()
         if numControlPoints >= 2:
-            parameterNode = self.getParameterNode()
             # Save current markup state to annotations
             self.syncMarkupsToAnnotations()
             # Update overlay display
             self.refreshDisplay(updateOverlay=True, updateGui=True)
+        elif parameterNode.lineBeingPlaced is None:
+            # Remove the line from the scene
+            if caller in self.pleuraLines:
+                self.pleuraLines.remove(caller)
+            elif caller in self.bLines:
+                self.bLines.remove(caller)
+            self._freeMarkupNode(caller)
 
             # Only set unsavedChanges if this is a user-initiated modification
             if not self._isProgrammaticUpdate:
@@ -2677,9 +2707,51 @@ class AnnotateUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
             # Update overlay display
             self.refreshDisplay(updateOverlay=True, updateGui=True)
 
+            self.addObserver(caller, caller.PointRemovedEvent, self.onPointRemoved)
+
             # Set unsavedChanges when user finishes placing a line (only if not programmatic)
             if not self._isProgrammaticUpdate:
                 parameterNode.unsavedChanges = True
+
+    def onPointRemoved(self, caller, event):
+        # Called when a markup node point is removed
+        logging.debug(f"onPointRemoved: {caller.GetName()} was removed")
+        removedNodeID = caller.GetID()
+        numControlPoints = caller.GetNumberOfControlPoints()
+        if numControlPoints < 2:
+            # Remove the line from the scene
+            if caller in self.pleuraLines:
+                self.pleuraLines.remove(caller)
+            elif caller in self.bLines:
+                self.bLines.remove(caller)
+            self._freeMarkupNode(caller)
+
+        parameterNode = self.getParameterNode()
+        parameterNode.unsavedChanges = True
+        self.syncMarkupsToAnnotations()
+        self.refreshDisplay(updateOverlay=True, updateGui=True)
+
+    def onMarkupNodeRemoved(self, caller, event):
+        removedNodes = {
+            node
+            for node in self.pleuraLines + self.bLines
+            if slicer.mrmlScene.GetNodeByID(node.GetID()) is None
+        }
+
+        if not removedNodes:
+            return
+
+        for node in removedNodes:
+            if node in self.pleuraLines:
+                self.pleuraLines.remove(node)
+            elif node in self.bLines:
+                self.bLines.remove(node)
+            logging.debug(f"onMarkupNodeRemoved: {node.GetName()} was removed")
+            # we do not call _freeMarkupNode as this node is already Removed from the scene and is gone
+        parameterNode = self.getParameterNode()
+        parameterNode.unsavedChanges = True
+        self.syncMarkupsToAnnotations()
+        self.refreshDisplay(updateOverlay=True, updateGui=True)
 
     def fanCornersFromSectorLine(self, p1, p2, center, r1, r2):
         op1 = np.array(p1) - np.array(center)

--- a/AnnotateUltrasound/Testing/Python/test_memory_cycling.py
+++ b/AnnotateUltrasound/Testing/Python/test_memory_cycling.py
@@ -62,7 +62,8 @@ class MemoryCyclingTest(ScriptedLoadableModuleTest):
         # Initialize test parameters
         self.current_frame = 0
         self.total_frames = 0
-        self.cycle_count = 0
+        self.draw_cycle_count = 0
+        self.play_cycle_count = 0
         self.max_cycles = 5  # Default number of cycles to run
         self.test_data_path = testDataPath
         self.dicom_file = "3038953328_70622118.dcm"
@@ -107,29 +108,38 @@ class MemoryCyclingTest(ScriptedLoadableModuleTest):
                         'memory_mb': memory_mb,
                         'action': action,
                         'frame': self.current_frame,
-                        'cycle': self.cycle_count
+                        'cycle': self.draw_cycle_count
                     })
-                    print(f"Memory: {memory_mb:.1f}MB | Frame: {self.current_frame} | Cycle: {self.cycle_count} | Action: {action}")
+                    print(f"Memory: {memory_mb:.1f}MB | Frame: {self.current_frame} | Cycle: {self.draw_cycle_count} | Action: {action}")
                 else:
                     self.memory_log.append({
                         'timestamp': timestamp,
                         'memory_mb': memory_mb,
                         'action': action,
-                        'cycle': self.cycle_count
+                        'cycle': self.play_cycle_count
                     })
-                    print(f"Memory: {memory_mb:.1f}MB | Cycle: {self.cycle_count} | Action: {action}")
+                    print(f"Memory: {memory_mb:.1f}MB | Cycle: {self.play_cycle_count} | Action: {action}")
             except Exception as e:
                 print(f"Could not log memory usage: {e}")
         else:
             # Log without memory info
-            self.memory_log.append({
-                'timestamp': timestamp,
-                'memory_mb': 0,  # Placeholder
-                'action': action,
-                'frame': self.current_frame,
-                'cycle': self.cycle_count
-            })
-            print(f"Frame: {self.current_frame} | Cycle: {self.cycle_count} | Action: {action}")
+            if not action.startswith("playback"):
+                self.memory_log.append({
+                    'timestamp': timestamp,
+                    'memory_mb': 0,  # Placeholder
+                    'action': action,
+                    'frame': self.current_frame,
+                    'cycle': self.draw_cycle_count
+                })
+                print(f"Frame: {self.current_frame} | Cycle: {self.draw_cycle_count} | Action: {action}")
+            else:
+                self.memory_log.append({
+                    'timestamp': timestamp,
+                    'memory_mb': 0,  # Placeholder
+                    'action': action,
+                    'cycle': self.play_cycle_count
+                })
+                print(f"Cycle: {self.play_cycle_count} | Action: {action}")
 
     def load_test_data(self):
         """Load the test DICOM and annotation data."""
@@ -352,13 +362,13 @@ class MemoryCyclingTest(ScriptedLoadableModuleTest):
                     return
 
             # Increment cycle count
-            self.cycle_count += 1
+            self.draw_cycle_count += 1
 
             # Force garbage collection
             gc.collect()
 
             # Log progress
-            print(f"Completed cycle {self.cycle_count}/{self.max_cycles}")
+            print(f"Completed cycle {self.draw_cycle_count}/{self.max_cycles}")
 
         except Exception as e:
             print(f"Error in cycle_frame: {e}")
@@ -373,7 +383,7 @@ class MemoryCyclingTest(ScriptedLoadableModuleTest):
                 return False
 
             # Set playback speed to 2.0 fps
-            self.logic.sequenceBrowserNode.SetPlaybackRateFPS(2.0)
+            self.logic.sequenceBrowserNode.SetPlaybackRateFps(2.0)
 
             # Start playback
             self.logic.sequenceBrowserNode.SetPlaybackActive(True)
@@ -390,7 +400,7 @@ class MemoryCyclingTest(ScriptedLoadableModuleTest):
             # Stop playback (in case it's still running)
             self.logic.sequenceBrowserNode.SetPlaybackActive(False)
             self.log_memory_usage("playback_completed")
-
+            self.play_cycle_count += 1
             print(f"Completed playback of {self.total_frames} frames")
             return True
 
@@ -417,12 +427,10 @@ class MemoryCyclingTest(ScriptedLoadableModuleTest):
         # Run drawing cycles
         print(f"\n=== PHASE 1: Drawing Cycles ({self.max_cycles} cycles) ===")
         for cycle in range(self.max_cycles):
-            self.cycle_count = cycle
             self.cycle_frame()
             time.sleep(1)  # Small delay between cycles
 
         # Run playback cycles
-        self.cycle_count = 0
         print(f"\n=== PHASE 2: Playback Cycles ({self.max_cycles} cycles) ===")
         for cycle in range(self.max_cycles):
             print(f"Playback cycle {cycle + 1}/{self.max_cycles}")
@@ -430,7 +438,6 @@ class MemoryCyclingTest(ScriptedLoadableModuleTest):
                 print("Failed to complete playback cycle")
                 break
             time.sleep(0.5)  # Small delay between playback cycles
-            self.cycle_count = cycle
 
         # Save memory log
         log_file = os.path.join(tempfile.gettempdir(), f"memory_cycling_test_{int(time.time())}.json")
@@ -438,8 +445,8 @@ class MemoryCyclingTest(ScriptedLoadableModuleTest):
             json.dump(self.memory_log, f, indent=2)
 
         print(f"\nMemory cycling test completed. Log saved to: {log_file}")
-        print(f"Total drawing cycles completed: {self.cycle_count}")
-        print(f"Total playback cycles completed: {self.max_cycles}")
+        print(f"Total drawing cycles completed: {self.draw_cycle_count}")
+        print(f"Total playback cycles completed: {self.play_cycle_count}")
 
         # Print summary
         if PSUTIL_AVAILABLE and self.memory_log:

--- a/AnnotateUltrasound/Testing/Python/test_memory_cycling.py
+++ b/AnnotateUltrasound/Testing/Python/test_memory_cycling.py
@@ -221,7 +221,6 @@ class MemoryCyclingTest(ScriptedLoadableModuleTest):
                                     # Get volume bounds to ensure lines are visible
             bounds = [0, 0, 0, 0, 0, 0]
             volumeNode.GetBounds(bounds)
-            print(f"Volume bounds: {bounds}")
 
             # Calculate offset based on current frame to move lines each frame
             # Move lines by a few pixels each frame, cycling back after 5 frames
@@ -250,16 +249,9 @@ class MemoryCyclingTest(ScriptedLoadableModuleTest):
             bline2_start = [-144.0 + offset_x, -85.0 + offset_y, 0.0]  # LPS to RAS: flip X and Y
             bline2_end = [-149.0 + offset_x, -84.0 + offset_y, 0.0]
 
-            print(f"Drawing lines with coordinates:")
-            print(f"  Pleura 1: {pleura1_start} to {pleura1_end}")
-            print(f"  Pleura 2: {pleura2_start} to {pleura2_end}")
-            print(f"  B-line 1: {bline1_start} to {bline1_end}")
-            print(f"  B-line 2: {bline2_start} to {bline2_end}")
-
             # Use the current rater from the logic
             parameterNode = self.logic.getParameterNode()
             rater = parameterNode.rater if parameterNode and parameterNode.rater else "test_rater"
-            print(f"Using rater: {rater}")
 
             # Ensure lines are visible
             self.logic.showHideLines = True


### PR DESCRIPTION
If the point or line is by the current rater, allow deletion. Lock nodes that aren't owned by the current rater.