### PR TITLE
Added Cmd/Ctrl+X for Cut

### DIFF
--- a/AnnotateUltrasound/AnnotateUltrasound.py
+++ b/AnnotateUltrasound/AnnotateUltrasound.py
@@ -354,7 +354,7 @@ class AnnotateUltrasoundWidget(ScriptedLoadableModuleWidget, CustomObserverMixin
             selected = list(self.logic.selectedLineIDs) # Save current selection
             self.onCopyLines()
             self.logic.selectedLineIDs = selected # Restore for delete, clipboard has the nodes we might paste later
-            self.onDeleteSelectedLines()
+            self.onDeleteSelectedLines(force=True) # don't ask for confirmation
             self.logic.selectedLineIDs = []
 
     def connectKeyboardShortcuts(self):
@@ -1609,7 +1609,7 @@ class AnnotateUltrasoundWidget(ScriptedLoadableModuleWidget, CustomObserverMixin
         raterNodes = []
         for nodeID in selectedIDs:
             node = slicer.mrmlScene.GetNodeByID(nodeID)
-            if node and (node.GetAttribute("rater") == self._parameterNode.rater or force):
+            if node and (node.GetAttribute("rater") == self._parameterNode.rater):
                 raterNodes.append(node)
 
         if len(raterNodes) == 0:


### PR DESCRIPTION
Cut will copy all lines in the frame to clipboard, and cut only the lines owned by the rater. It is basically Copy+Delete so it copies all lines, but only Deletes what it is allowed to. Pasting in a new frame will paste all the lines copied, not just the ones that were owned by the rater.

Also cleaned up freeing of nodes from Clipboard to make sure we don't leak inadvertantly.