### PR TITLE
Update sequence browser toolbar button tooltips to reflect custom shortcuts

### DIFF
--- a/AnnotateUltrasound/AnnotateUltrasound.py
+++ b/AnnotateUltrasound/AnnotateUltrasound.py
@@ -649,6 +649,9 @@ class AnnotateUltrasoundWidget(ScriptedLoadableModuleWidget, CustomObserverMixin
         sliceView.installEventFilter(self.sliceViewEventFilter)
         self.sliceView = sliceView  # Save reference so it's not GC'ed
 
+        # Customize sequence browser toolbar button tooltips
+        self._customizeSequenceBrowserTooltips()
+
     def distanceToLineSegment2D(self, p, a, b):
         """Squared distance from point p to segment ab in 2D (XY only)."""
         px, py = p[0], p[1]
@@ -2358,6 +2361,33 @@ class AnnotateUltrasoundWidget(ScriptedLoadableModuleWidget, CustomObserverMixin
 
         self.logic.refreshDisplay(updateOverlay=True, updateGui=True)
         self._setRedViewFocus()
+
+    def _customizeSequenceBrowserTooltips(self):
+        """Customize the tooltips of sequence browser toolbar buttons to reflect custom shortcuts."""
+        try:
+            logging.info("Customizing sequence browser tooltips")
+            # Get the sequence browser toolbar
+            sequenceToolBar = slicer.modules.sequences.toolBar()
+
+            # Find all buttons in the toolbar
+            buttons = sequenceToolBar.findChildren(qt.QPushButton)
+
+            for button in buttons:
+                # Look for the next frame button by checking its tooltip or object name
+                currentTooltip = button.toolTip
+
+                # Update the "Next Frame" button tooltip
+                if "Next frame" in currentTooltip and "Ctrl+Shift+Right" in currentTooltip:
+                    button.setToolTip("Next Frame (Right)")
+                    logging.info("Updated Next Frame button tooltip to show 'Right' shortcut")
+
+                # Optionally, also update the "Previous Frame" button
+                elif "Previous frame" in currentTooltip and "Ctrl+Shift+Left" in currentTooltip:
+                    button.setToolTip("Previous Frame (Left)")
+                    logging.info("Updated Previous Frame button tooltip to show 'Left' shortcut")
+
+        except Exception as e:
+            logging.warning(f"Could not customize sequence browser tooltips: {e}")
 
 #
 # AnnotateUltrasoundLogic


### PR DESCRIPTION
**Problem:**
The "Next Frame" and "Previous Frame" buttons in the sequence browser toolbar display tooltips showing the default Slicer shortcuts (Ctrl+Shift+Right/Left), but the AnnotateUltrasound module overrides these with simpler Right/Left arrow key shortcuts.

**Solution:**
- Added _customizeSequenceBrowserTooltips() method to update toolbar button tooltips
- Changed "Next Frame" tooltip from "Next Frame (Ctrl+Shift+Right)" to "Next Frame (Right)"
- Changed "Previous Frame" tooltip from "Previous Frame (Ctrl+Shift+Left)" to "Previous Frame (Left)"
- Added logging to track tooltip customization
- Fixed case sensitivity in tooltip text matching ("Next frame" vs "Next Frame")

**Impact:**
Users now see accurate shortcut information when hovering over frame navigation buttons, reducing confusion about which keys to press.

<img width="3456" height="2234" alt="Screenshot 2025-08-12 at 11 06 19 AM" src="https://github.com/user-attachments/assets/5abc4483-9c08-48ac-bf5c-270db4ac895a" />
<img width="3456" height="2234" alt="Screenshot 2025-08-12 at 11 06 31 AM" src="https://github.com/user-attachments/assets/7d8707d9-b802-4809-8b61-91beddb6060f" />
