### PR TITLE
COMP: Fix Windows build by removing redundant AnnotateUltrasound resources

### DIFF
--- a/AdjudicateUltrasound/CMakeLists.txt
+++ b/AdjudicateUltrasound/CMakeLists.txt
@@ -4,25 +4,10 @@ set(MODULE_NAME AdjudicateUltrasound)
 #-----------------------------------------------------------------------------
 set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/../AnnotateUltrasound/AnnotateUltrasound.py
   )
 
 set(MODULE_ICON_PNGS
   Resources/Icons/AdjudicateUltrasound.png
-  "${CMAKE_CURRENT_SOURCE_DIR}/../AnnotateUltrasound/Resources/Icons/blueAdd.png"
-  "${CMAKE_CURRENT_SOURCE_DIR}/../AnnotateUltrasound/Resources/Icons/blueEye.png"
-  "${CMAKE_CURRENT_SOURCE_DIR}/../AnnotateUltrasound/Resources/Icons/blueFastForward.png"
-  "${CMAKE_CURRENT_SOURCE_DIR}/../AnnotateUltrasound/Resources/Icons/blueFillNext.png"
-  "${CMAKE_CURRENT_SOURCE_DIR}/../AnnotateUltrasound/Resources/Icons/blueFillPrevious.png"
-  "${CMAKE_CURRENT_SOURCE_DIR}/../AnnotateUltrasound/Resources/Icons/BlueFillTrash.png"
-  "${CMAKE_CURRENT_SOURCE_DIR}/../AnnotateUltrasound/Resources/Icons/blueRemove.png"
-  "${CMAKE_CURRENT_SOURCE_DIR}/../AnnotateUltrasound/Resources/Icons/blueSave.png"
-)
-
-set(MODULE_PYTHON_RESOURCES
-  ${MODULE_ICON_PNGS}
-  "${CMAKE_CURRENT_SOURCE_DIR}/../AnnotateUltrasound/Resources/UI/AnnotateUltrasound.ui"
-  "${CMAKE_CURRENT_SOURCE_DIR}/../AnnotateUltrasound/Resources/annotation_labels.csv"
   )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This change removes the superfluous copy of AnnotateUltrasound resources, which caused errors with the Visual Studio generator:

```
Cannot evaluate the item metadata "%(RootDir)". The item metadata "%(FullPath)" cannot be applied to the path "C:\D\S\S-0-E-b\Ultrasound-build\lib\Slicer-5.8\qt-scripted-modules\C:\D\S\S-0-E-b\Ultrasound\AnnotateUltrasound\Resources\Icons\BlueFillTrash.png". The given path's format is not supported.
```