### PR TITLE
Addressing build error on Slicer dashboard due to escape character

### DIFF
--- a/AnnotateUltrasound/AnnotateUltrasound.py
+++ b/AnnotateUltrasound/AnnotateUltrasound.py
@@ -1672,7 +1672,7 @@ class AnnotateUltrasoundWidget(ScriptedLoadableModuleWidget, CustomObserverMixin
         def humanize(text):
             # Split on CamelCase, handling consecutive capitals
             # This will split "LiverSpleenDiaphragm" into ["Liver", "Spleen", "Diaphragm"]
-            words = re.findall('[A-Z][a-z\d]+|[A-Z\d]+(?=[A-Z][a-z\d]|[^a-zA-Z\d]|$)|[a-z\d]+', text)
+            words = re.findall(r'[A-Z][a-z\d]+|[A-Z\d]+(?=[A-Z][a-z\d]|[^a-zA-Z\d]|$)|[a-z\d]+', text)
             return ' '.join(words)
         # Create widgets with humanized display text
         for category, labels in categories.items():

--- a/AnonymizeUltrasound/AnonymizeUltrasound.py
+++ b/AnonymizeUltrasound/AnonymizeUltrasound.py
@@ -636,7 +636,7 @@ class AnonymizeUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         def humanize(text):
             # Split on CamelCase, handling consecutive capitals
             # This will split "LiverSpleenDiaphragm" into ["Liver", "Spleen", "Diaphragm"]
-            words = re.findall('[A-Z][a-z\d]+|[A-Z\d]+(?=[A-Z][a-z\d]|[^a-zA-Z\d]|$)|[a-z\d]+', text)
+            words = re.findall(r'[A-Z][a-z\d]+|[A-Z\d]+(?=[A-Z][a-z\d]|[^a-zA-Z\d]|$)|[a-z\d]+', text)
             return ' '.join(words)
         # Create widgets with humanized display text
         for category, labels in categories.items():


### PR DESCRIPTION
I've noticed that build errors are reported on the Slicer build machine: https://slicer.cdash.org/viewBuildError.php?buildid=3965997

Would adding an "r" in front of the strings solve this issue?