### PR TITLE
Handle empty DataFrame when no DICOM files found during import

### DIFF
--- a/AnnotateUltrasound/AnnotateUltrasound.py
+++ b/AnnotateUltrasound/AnnotateUltrasound.py
@@ -3704,12 +3704,12 @@ class AnnotateUltrasoundLogic(ScriptedLoadableModuleLogic, CustomObserverMixin, 
             if displayNode:
                 displayNode.SetWindow(255)
                 displayNode.SetLevel(127)
-                                # For label volumes, use a simple color map that shows cyan for non-zero values
+
+                # For label volumes, use a simple color map that shows cyan for non-zero values
                 # Create a custom color table that maps non-zero values to cyan
                 colorNode = slicer.vtkMRMLColorTableNode()
                 colorNode.SetTypeToUser()
                 colorNode.SetNumberOfColors(256)
-                colorNode.SetNamesInitialised(True)
 
                 # Set all colors to transparent except for non-zero values which will be cyan
                 for i in range(256):

--- a/AnonymizeUltrasound/AnonymizeUltrasound.py
+++ b/AnonymizeUltrasound/AnonymizeUltrasound.py
@@ -853,7 +853,7 @@ class AnonymizeUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             self._parameterNode.status = AnonymizerStatus.INITIAL
 
         # Export self.logic.dicom_manager.dicom_df as a CSV file in the headers directory
-        if self.logic.dicom_manager.dicom_df is not None:
+        if self.logic.dicom_manager.dicom_df is not None and not self.logic.dicom_manager.dicom_df.empty:
             outputFilePath = os.path.join(outputHeadersDirectory, "keys.csv")
             self.logic.dicom_manager.dicom_df.drop(columns=['DICOMDataset'], inplace=False).to_csv(outputFilePath, index=False)
 


### PR DESCRIPTION
## Summary

Handles `KeyError` exception when clicking "Import DICOM" on a folder with no valid DICOM files.

## Problem

When no DICOM files are found, `DicomFileManager` creates an empty DataFrame (`pd.DataFrame()`).
The check `if dicom_df is not None` passes, but the subsequent `drop(columns=['DICOMDataset'])` fails because an empty DataFrame has no columns.

```
KeyError: "['DICOMDataset'] not found in axis"
```

## Solution

Add `.empty` check before attempting to export the DataFrame to CSV.

## Test Plan

- [x] **Empty folder**: Import from empty directory → shows "0 files found", no crash
- [x] **No valid files**: Import from folder with non-DICOM or non-ultrasound files → no crash
- [x] **Regression**: Import valid DICOM files → `keys.csv` created, workflow works normally

## Additional changes

- Remove SetNamesInitialised() method because it is deprecated in slicer 5.10.
  Removing it does not impact annotation performace.

```
SetNamesInitialised() method is deprecated and has no effect. Use SetColorName() and SetColorDefined() methods instead.
```

