### PR TITLE
Extract transducer data and refine de-id metadata preservation

### DIFF
--- a/AnonymizeUltrasound/AnonymizeUltrasound.py
+++ b/AnonymizeUltrasound/AnonymizeUltrasound.py
@@ -1679,8 +1679,7 @@ class AnonymizeUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin)
         # If found, apply it. If not, the user will need to define it manually.
         if self.dicom_manager.dicom_df is not None:
             current_dicom_record = self.dicom_manager.dicom_df.iloc[self.dicom_manager.current_index]
-            transducerType = current_dicom_record.get("TransducerModel", "unknown")
-            self.currentTransducerModel = self.dicom_manager.get_transducer_model(transducerType)
+            self.currentTransducerModel = current_dicom_record.get("TransducerModel", "unknown")
             cached_mask = self.getCachedMaskForTransducer(self.currentTransducerModel)
 
             if cached_mask:

--- a/AnonymizeUltrasound/common/dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/dicom_file_manager.py
@@ -94,6 +94,22 @@ class DicomFileManager:
         self.next_index = 0
         self.current_index = 0
 
+    def _first_transducer_segment(self, raw) -> str:
+        """Return the first segment of a TransducerData-like value with case preserved.
+
+        Handles plain strings (comma- or backslash-delimited) and pydicom MultiValue
+        objects (auto-split by VR LO separator). Returns an empty string for None,
+        empty, or whitespace-only input.
+        """
+        if raw is not None and not isinstance(raw, str) and hasattr(raw, '__getitem__'):
+            raw = raw[0] if len(raw) > 0 else ''
+
+        source = str(raw).strip() if raw is not None else ''
+        if not source:
+            return ''
+
+        return source.split('\\')[0].split(',')[0].strip()
+
     def get_transducer_model(self, transducer_data, manufacturer: str = '',
                              manufacturer_model_name: str = '') -> str:
         """
@@ -112,15 +128,8 @@ class DicomFileManager:
         else:
             raw = transducer_data
 
-        if raw is not None and not isinstance(raw, str) and hasattr(raw, '__getitem__'):
-            raw = raw[0] if len(raw) > 0 else ''
-
-        source = str(raw).strip() if raw is not None else ''
-        if not source:
-            return 'unknown'
-
-        model = source.split('\\')[0].split(',')[0].strip().lower()
-        return model if model else 'unknown'
+        segment = self._first_transducer_segment(raw)
+        return segment.lower() if segment else 'unknown'
 
     def scan_directory(self, input_folder: str, skip_single_frame: bool = False, hash_patient_id: bool = True) -> int:
         """
@@ -569,6 +578,8 @@ class DicomFileManager:
 
         for tag in self.DICOM_TAGS_PRESERVE_OR_BLANK:
             value = getattr(source_ds, tag, '') or ''
+            if tag == 'TransducerData':
+                value = self._first_transducer_segment(value)
             setattr(ds, tag, value)
 
         # Handle UIDs

--- a/AnonymizeUltrasound/common/dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/dicom_file_manager.py
@@ -55,7 +55,7 @@ class DicomFileManager:
         "StudyDate",
         "StudyDescription",
         "StudyTime",
-        "TransducerType",
+        "TransducerData",
         "Manufacturer"
     ]
 
@@ -88,15 +88,15 @@ class DicomFileManager:
         self.next_index = 0
         self.current_index = 0
 
-    def get_transducer_model(self, transducerType: str) -> str:
+    def get_transducer_model(self, transducerData: str) -> str:
         """
-        Parse the transducer type string and return the transducer model or 'unknown'.
-        For example, if transducerType is 'SC6-1s,02597', it returns 'sc6-1s'.
+        Parse the transducer data string and return the transducer model or 'unknown'.
+        For example, if transducerData is 'SC6-1s,02597', it returns 'sc6-1s'.
         """
-        if not transducerType or transducerType.strip() == '':
+        if not transducerData or transducerData.strip() == '':
             return 'unknown'
 
-        return transducerType.split(",")[0].lower()
+        return transducerData.split(",")[0].lower()
 
     def scan_directory(self, input_folder: str, skip_single_frame: bool = False, hash_patient_id: bool = True) -> int:
         """
@@ -180,7 +180,7 @@ class DicomFileManager:
             content_date = getattr(dicom_ds, 'ContentDate', '19000101')
             content_time = getattr(dicom_ds, 'ContentTime', '000000')
             to_patch = physical_delta_x is None or physical_delta_y is None
-            transducer_model = self.get_transducer_model(dicom_ds.get('TransducerType', ''))
+            transducer_model = self.get_transducer_model(dicom_ds.get('TransducerData', ''))
 
             # Calculate relative path from input folder. Replace the filename with the anonymized filename.
             output_path = os.path.relpath(file_path, input_folder).replace(os.path.basename(file_path), anon_filename)

--- a/AnonymizeUltrasound/common/dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/dicom_file_manager.py
@@ -42,6 +42,10 @@ class DicomFileManager:
     DICOM_EXTENSIONS = {'.dcm', '.dicom'}
 
     # Tags copied from source only if present (allowlist semantics).
+    # Intentionally excluded for HIPAA Safe Harbor compliance:
+    #   - StationName (0008,1010): device/room/institution identifier
+    #   - StudyDescription (0008,1030): free-text field that frequently
+    #     contains patient names, physician initials, or referral info
     DICOM_TAGS_TO_COPY = [
         "BitsAllocated",
         "BitsStored",
@@ -50,9 +54,7 @@ class DicomFileManager:
         "PatientSex",
         "PixelRepresentation",
         "SeriesNumber",
-        "StationName",
         "StudyDate",
-        "StudyDescription",
         "StudyTime",
         "Manufacturer",
     ]
@@ -624,8 +626,28 @@ class DicomFileManager:
         ds.ReferringPhysicianName = ""
         ds.AccessionNumber = ""
 
+        # HIPAA Safe Harbor: aggregate ages >89 years to "090Y".
+        if hasattr(ds, 'PatientAge'):
+            ds.PatientAge = self._cap_patient_age(ds.PatientAge)
+
         # Apply date shifting for anonymization
         self._apply_date_shifting(ds, source_ds)
+
+    def _cap_patient_age(self, age_str) -> str:
+        """Cap PatientAge at '090Y' for ages >= 90 years (HIPAA Safe Harbor).
+
+        DICOM AS format is 'nnnX' where X is D, W, M, or Y. Only year values
+        are capped; day/week/month values pass through unchanged (they can't
+        reach 89 years in those units within the format's 3-digit field).
+        Invalid or malformed values pass through unchanged.
+        """
+        if not isinstance(age_str, str) or len(age_str) != 4 or not age_str.endswith('Y'):
+            return age_str
+        try:
+            years = int(age_str[:3])
+        except ValueError:
+            return age_str
+        return '090Y' if years >= 90 else age_str
 
     def _shift_date(self, date_str: str, offset: int) -> str:
         """Shift a single date by the given offset."""

--- a/AnonymizeUltrasound/common/dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/dicom_file_manager.py
@@ -41,12 +41,11 @@ class DicomFileManager:
     # Define allowed DICOM file extensions (case-insensitive)
     DICOM_EXTENSIONS = {'.dcm', '.dicom'}
 
-    # DICOM tags to copy directly
+    # Tags copied from source only if present (allowlist semantics).
     DICOM_TAGS_TO_COPY = [
         "BitsAllocated",
         "BitsStored",
         "HighBit",
-        "ManufacturerModelName",
         "PatientAge",
         "PatientSex",
         "PixelRepresentation",
@@ -55,8 +54,15 @@ class DicomFileManager:
         "StudyDate",
         "StudyDescription",
         "StudyTime",
+        "Manufacturer",
+    ]
+
+    # Tags always written to the de-id dataset: source value if present, else "".
+    # Downstream consumers rely on these tags being present on every anonymized DICOM.
+    DICOM_TAGS_PRESERVE_OR_BLANK = [
         "TransducerData",
-        "Manufacturer"
+        "TransducerType",
+        "ManufacturerModelName",
     ]
 
     # Expected columns in the DICOM files dataframe
@@ -88,15 +94,33 @@ class DicomFileManager:
         self.next_index = 0
         self.current_index = 0
 
-    def get_transducer_model(self, transducerData: str) -> str:
+    def get_transducer_model(self, transducer_data, manufacturer: str = '',
+                             manufacturer_model_name: str = '') -> str:
         """
-        Parse the transducer data string and return the transducer model or 'unknown'.
-        For example, if transducerData is 'SC6-1s,02597', it returns 'sc6-1s'.
+        Parse the transducer model identifier from DICOM metadata.
+
+        For Butterfly Network manufacturers, the device identifier is stored in
+        ManufacturerModelName (0008,1090) rather than TransducerData (0018,5010).
+        For other vendors, TransducerData may be comma-delimited ('SC6-1s,02597')
+        or backslash-delimited ('S4-1U\\UNUSED\\UNUSED'); pydicom may return the
+        latter as a MultiValue because backslash is the native VR LO separator.
+
+        Returns the lowercased model identifier, or 'unknown' if unavailable.
         """
-        if not transducerData or transducerData.strip() == '':
+        if 'butterfly' in str(manufacturer or '').lower():
+            raw = manufacturer_model_name
+        else:
+            raw = transducer_data
+
+        if raw is not None and not isinstance(raw, str) and hasattr(raw, '__getitem__'):
+            raw = raw[0] if len(raw) > 0 else ''
+
+        source = str(raw).strip() if raw is not None else ''
+        if not source:
             return 'unknown'
 
-        return transducerData.split(",")[0].lower()
+        model = source.split('\\')[0].split(',')[0].strip().lower()
+        return model if model else 'unknown'
 
     def scan_directory(self, input_folder: str, skip_single_frame: bool = False, hash_patient_id: bool = True) -> int:
         """
@@ -180,7 +204,11 @@ class DicomFileManager:
             content_date = getattr(dicom_ds, 'ContentDate', '19000101')
             content_time = getattr(dicom_ds, 'ContentTime', '000000')
             to_patch = physical_delta_x is None or physical_delta_y is None
-            transducer_model = self.get_transducer_model(dicom_ds.get('TransducerData', ''))
+            transducer_model = self.get_transducer_model(
+                dicom_ds.get('TransducerData', ''),
+                manufacturer=dicom_ds.get('Manufacturer', ''),
+                manufacturer_model_name=dicom_ds.get('ManufacturerModelName', ''),
+            )
 
             # Calculate relative path from input folder. Replace the filename with the anonymized filename.
             output_path = os.path.relpath(file_path, input_folder).replace(os.path.basename(file_path), anon_filename)
@@ -538,6 +566,10 @@ class DicomFileManager:
         for tag in self.DICOM_TAGS_TO_COPY:
             if hasattr(source_ds, tag):
                 setattr(ds, tag, getattr(source_ds, tag))
+
+        for tag in self.DICOM_TAGS_PRESERVE_OR_BLANK:
+            value = getattr(source_ds, tag, '') or ''
+            setattr(ds, tag, value)
 
         # Handle UIDs
         self._copy_and_generate_uids(ds, source_ds, output_path)

--- a/AnonymizeUltrasound/common/dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/dicom_file_manager.py
@@ -42,10 +42,6 @@ class DicomFileManager:
     DICOM_EXTENSIONS = {'.dcm', '.dicom'}
 
     # Tags copied from source only if present (allowlist semantics).
-    # Intentionally excluded for HIPAA Safe Harbor compliance:
-    #   - StationName (0008,1010): device/room/institution identifier
-    #   - StudyDescription (0008,1030): free-text field that frequently
-    #     contains patient names, physician initials, or referral info
     DICOM_TAGS_TO_COPY = [
         "BitsAllocated",
         "BitsStored",
@@ -54,7 +50,9 @@ class DicomFileManager:
         "PatientSex",
         "PixelRepresentation",
         "SeriesNumber",
+        "StationName",
         "StudyDate",
+        "StudyDescription",
         "StudyTime",
         "Manufacturer",
     ]
@@ -580,8 +578,6 @@ class DicomFileManager:
 
         for tag in self.DICOM_TAGS_PRESERVE_OR_BLANK:
             value = getattr(source_ds, tag, '') or ''
-            if tag == 'TransducerData':
-                value = self._first_transducer_segment(value)
             setattr(ds, tag, value)
 
         # Handle UIDs
@@ -606,8 +602,14 @@ class DicomFileManager:
             logging.error(f"SOPInstanceUID not found. Generating new one for {output_path}")
             ds.SOPInstanceUID = pydicom.uid.generate_uid()
 
-        # Generate a unique SeriesInstanceUID. This is because ultrasound machines often reuse the same SeriesInstanceUID, which can cause issues in the viewer.
-        ds.SeriesInstanceUID = pydicom.uid.generate_uid()
+        # Copy or generate SeriesInstanceUID. Pass-through preserves series-level
+        # linkage between source and de-id outputs; callers must accept that
+        # ultrasound-machine UID reuse may cause viewer collisions downstream.
+        if hasattr(source_ds, 'SeriesInstanceUID') and source_ds.SeriesInstanceUID:
+            ds.SeriesInstanceUID = source_ds.SeriesInstanceUID
+        else:
+            logging.error(f"SeriesInstanceUID not found. Generating new one for {output_path}")
+            ds.SeriesInstanceUID = pydicom.uid.generate_uid()
 
         # Copy or generate StudyInstanceUID
         if hasattr(source_ds, 'StudyInstanceUID') and source_ds.StudyInstanceUID:
@@ -939,7 +941,7 @@ class DicomFileManager:
         output = np.zeros((num_frames, height, width, channels), dtype=np.uint8)
 
         try:
-            logging.info(f"Trying `dicom.encaps.generate_pixel_data_frame`")
+            logging.info("Trying `dicom.encaps.generate_pixel_data_frame`")
             pixel_data_frames = generate_pixel_data_frame(ds.PixelData)
 
             for i in range(num_frames):
@@ -951,6 +953,7 @@ class DicomFileManager:
                     frame = np.expand_dims(frame, axis=2)
                 output[i, :, :, :] = frame
         except Exception as e:
+            logging.warning("dicom.encaps.generate_pixel_data_frame approach failed: %s", e)
             try:
                 logging.info("Fallback to decode_data_sequence approach")
                 frame_data = decode_data_sequence(ds.PixelData)
@@ -966,6 +969,7 @@ class DicomFileManager:
                     output[i, :, :, :] = frame
 
             except Exception as e:
+                logging.warning("decode_data_sequence approach failed: %s", e)
                 try:
                     logging.info("Fallback to ds.pixel_array approach")
                     pixel_data_frames = ds.pixel_array # this seems to be more robust? but slower

--- a/AnonymizeUltrasound/common/dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/dicom_file_manager.py
@@ -636,17 +636,31 @@ class DicomFileManager:
     def _cap_patient_age(self, age_str) -> str:
         """Cap PatientAge at '090Y' for ages >= 90 years (HIPAA Safe Harbor).
 
-        DICOM AS format is 'nnnX' where X is D, W, M, or Y. Only year values
-        are capped; day/week/month values pass through unchanged (they can't
-        reach 89 years in those units within the format's 3-digit field).
-        Invalid or malformed values pass through unchanged.
+        DICOM AS format is 'nnnX' where nnn is three digits and X is one of
+        D (days), W (weeks), M (months), or Y (years). Only year values are
+        capped; D/W/M values and empty strings pass through unchanged.
+        Malformed values are logged at ERROR and passed through so source
+        data is never silently rewritten.
         """
-        if not isinstance(age_str, str) or len(age_str) != 4 or not age_str.endswith('Y'):
+        if not isinstance(age_str, str) or age_str == '':
             return age_str
-        try:
-            years = int(age_str[:3])
-        except ValueError:
+
+        is_valid_as = (
+            len(age_str) == 4
+            and age_str[-1] in ('D', 'W', 'M', 'Y')
+            and age_str[:3].isdigit()
+        )
+        if not is_valid_as:
+            logging.error(
+                f"Invalid PatientAge value {age_str!r}; "
+                "expected DICOM AS format 'nnnX' with X in (D, W, M, Y), e.g. '045Y'"
+            )
             return age_str
+
+        if age_str[-1] != 'Y':
+            return age_str
+
+        years = int(age_str[:3])
         return '090Y' if years >= 90 else age_str
 
     def _shift_date(self, date_str: str, offset: int) -> str:

--- a/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
@@ -3,6 +3,7 @@ import os
 import sys
 import tempfile
 import shutil
+import logging
 import pandas as pd
 import pydicom
 import numpy as np
@@ -1015,6 +1016,47 @@ class TestDicomFileManager:
         source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
         manager_with_data._apply_anonymization(ds, source_ds)
         assert ds.PatientAge == "025M"
+
+    def test_cap_patient_age_logs_error_for_invalid_format(self, manager, caplog):
+        """Malformed PatientAge values are logged at ERROR with value + expected format, then passed through"""
+        with caplog.at_level(logging.ERROR):
+            result = manager._cap_patient_age("25YR")
+
+        assert result == "25YR"
+        assert any("25YR" in r.message for r in caplog.records), "log should include the invalid value"
+        assert any("nnnX" in r.message for r in caplog.records), "log should include the expected format"
+
+    def test_cap_patient_age_logs_error_for_bad_unit(self, manager, caplog):
+        """Values with an invalid unit letter are flagged as errors"""
+        with caplog.at_level(logging.ERROR):
+            result = manager._cap_patient_age("045X")
+
+        assert result == "045X"
+        assert any("045X" in r.message for r in caplog.records)
+
+    def test_cap_patient_age_logs_error_for_non_digit_prefix(self, manager, caplog):
+        """Values whose prefix isn't three digits are flagged as errors"""
+        with caplog.at_level(logging.ERROR):
+            result = manager._cap_patient_age("abcY")
+
+        assert result == "abcY"
+        assert any("abcY" in r.message for r in caplog.records)
+
+    def test_cap_patient_age_silent_for_empty(self, manager, caplog):
+        """Empty PatientAge is a valid 'no value' state and should not log an error"""
+        with caplog.at_level(logging.ERROR):
+            result = manager._cap_patient_age("")
+
+        assert result == ""
+        assert len(caplog.records) == 0
+
+    def test_cap_patient_age_silent_for_valid_non_year(self, manager, caplog):
+        """Valid non-year DICOM AS values should not log an error"""
+        with caplog.at_level(logging.ERROR):
+            for value in ("025M", "014D", "003W"):
+                assert manager._cap_patient_age(value) == value
+
+        assert len(caplog.records) == 0
 
     def test_copy_source_metadata_preserves_transducer_type(self, manager_with_data, temp_dir):
         """Test TransducerType present in source is preserved in de-id output"""

--- a/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
@@ -962,6 +962,60 @@ class TestDicomFileManager:
         assert hasattr(ds, 'BitsAllocated')
         assert hasattr(ds, 'TransducerData')
 
+    def test_copy_source_metadata_excludes_station_name(self, manager_with_data, temp_dir):
+        """StationName (0008,1010) is a device/location identifier and must not leak to de-id"""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.StationName = "US_ROOM_3B"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert not hasattr(ds, 'StationName')
+
+    def test_copy_source_metadata_excludes_study_description(self, manager_with_data, temp_dir):
+        """StudyDescription is a free-text field that frequently contains PHI; must not leak"""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.StudyDescription = "Patient Jane Doe referred by Dr Smith"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert not hasattr(ds, 'StudyDescription')
+
+    def test_apply_anonymization_caps_patient_age_over_89(self, manager_with_data):
+        """PatientAge >= 90 years is capped at '090Y' per HIPAA Safe Harbor"""
+        ds = pydicom.Dataset()
+        ds.PatientAge = "095Y"
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        manager_with_data._apply_anonymization(ds, source_ds)
+        assert ds.PatientAge == "090Y"
+
+    def test_apply_anonymization_caps_patient_age_exactly_90(self, manager_with_data):
+        """PatientAge of exactly 90 years is also capped (boundary)"""
+        ds = pydicom.Dataset()
+        ds.PatientAge = "090Y"
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        manager_with_data._apply_anonymization(ds, source_ds)
+        assert ds.PatientAge == "090Y"
+
+    def test_apply_anonymization_preserves_patient_age_under_90(self, manager_with_data):
+        """PatientAge under 90 years passes through unchanged"""
+        ds = pydicom.Dataset()
+        ds.PatientAge = "045Y"
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        manager_with_data._apply_anonymization(ds, source_ds)
+        assert ds.PatientAge == "045Y"
+
+    def test_apply_anonymization_preserves_non_year_patient_age(self, manager_with_data):
+        """Non-year PatientAge formats (months, weeks, days) are not affected by the 90Y cap"""
+        ds = pydicom.Dataset()
+        ds.PatientAge = "025M"
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        manager_with_data._apply_anonymization(ds, source_ds)
+        assert ds.PatientAge == "025M"
+
     def test_copy_source_metadata_preserves_transducer_type(self, manager_with_data, temp_dir):
         """Test TransducerType present in source is preserved in de-id output"""
         ds = pydicom.Dataset()

--- a/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
@@ -1024,6 +1024,40 @@ class TestDicomFileManager:
         assert hasattr(ds, 'TransducerData')
         assert ds.TransducerData == ""
 
+    def test_copy_source_metadata_strips_transducer_data_serial(self, manager_with_data, temp_dir):
+        """TransducerData in de-id retains only the model segment, not the serial number"""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.TransducerData = "SC6-1s,JK9U41102597"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert ds.TransducerData == "SC6-1s"
+
+    def test_copy_source_metadata_strips_transducer_data_backslash(self, manager_with_data, temp_dir):
+        """Backslash-delimited TransducerData is stripped to model segment only"""
+        from pydicom.multival import MultiValue
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.TransducerData = MultiValue(str, ["S4-1U", "UNUSED", "UNUSED"])
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert ds.TransducerData == "S4-1U"
+
+    def test_copy_source_metadata_preserves_transducer_data_case(self, manager_with_data, temp_dir):
+        """TransducerData model segment in de-id preserves original case (unlike TransducerModel DataFrame column)"""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.TransducerData = "C1-5"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert ds.TransducerData == "C1-5"
+
     def test_apply_anonymization_generates_uids_when_none_provided(self, manager_with_data):
         """Test that _apply_anonymization generates UIDs when no patient info provided"""
         ds = pydicom.Dataset()

--- a/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
@@ -27,7 +27,7 @@ class TestDicomFileManager:
     NUMBER_OF_FRAMES = 10
     CONTENT_DATE = "20240101"
     CONTENT_TIME = "120000"
-    TRANSDUCER_TYPE = "SC6-1s,02597"
+    TRANSDUCER_DATA = "SC6-1s,02597"
     TRANSDUCER_MODEL = "sc6-1s"
     ROWS = 4
     COLUMNS = 6
@@ -73,7 +73,7 @@ class TestDicomFileManager:
             'NumberOfFrames': self.NUMBER_OF_FRAMES,
             'ContentDate': self.CONTENT_DATE,
             'ContentTime': self.CONTENT_TIME,
-            'TransducerType': self.TRANSDUCER_TYPE,
+            'TransducerData': self.TRANSDUCER_DATA,
             'Rows': self.ROWS,
             'Columns': self.COLUMNS,
             'BitsAllocated': self.BITS_ALLOCATED,
@@ -468,7 +468,7 @@ class TestDicomFileManager:
             "Number of Frames": str(self.NUMBER_OF_FRAMES),
             "Content Date": self.CONTENT_DATE,
             "Content Time": self.CONTENT_TIME,
-            "Transducer Type": self.TRANSDUCER_TYPE,
+            "Transducer Data": self.TRANSDUCER_DATA,
             "Rows": self.ROWS,
             "Columns": self.COLUMNS,
             "Bits Allocated": self.BITS_ALLOCATED,
@@ -901,7 +901,7 @@ class TestDicomFileManager:
 
         # But these should still be copied
         assert hasattr(ds, 'BitsAllocated')
-        assert hasattr(ds, 'TransducerType')
+        assert hasattr(ds, 'TransducerData')
 
     def test_apply_anonymization_generates_uids_when_none_provided(self, manager_with_data):
         """Test that _apply_anonymization generates UIDs when no patient info provided"""

--- a/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
@@ -1,6 +1,5 @@
 import pytest
 import os
-import sys
 import tempfile
 import shutil
 import logging
@@ -289,7 +288,7 @@ class TestDicomFileManager:
         assert result['InstanceUID'] == self.SOP_INSTANCE_UID
         assert result['ContentDate'] == self.CONTENT_DATE
         assert result['ContentTime'] == self.CONTENT_TIME
-        assert result['Patch'] == False
+        assert result['Patch'] is False
         assert result['TransducerModel'] == self.TRANSDUCER_MODEL
         assert result['PhysicalDeltaX'] == self.PHYSICAL_DELTA_X
         assert result['PhysicalDeltaY'] == self.PHYSICAL_DELTA_Y
@@ -796,8 +795,8 @@ class TestDicomFileManager:
         assert ds.SOPClassUID == source_ds.SOPClassUID
         assert ds.SOPInstanceUID == source_ds.SOPInstanceUID
         assert ds.StudyInstanceUID == source_ds.StudyInstanceUID
-        # SeriesInstanceUID should always be generated new
-        assert ds.SeriesInstanceUID != source_ds.SeriesInstanceUID
+        # SeriesInstanceUID should now be copied from source
+        assert ds.SeriesInstanceUID == source_ds.SeriesInstanceUID
 
     def test_copy_and_generate_uids_missing_source_uids(self, manager_with_data, temp_dir):
         """Test _copy_and_generate_uids with missing UIDs in source"""
@@ -914,7 +913,7 @@ class TestDicomFileManager:
         assert ds.LossyImageCompression == '01'
         assert ds.LossyImageCompressionMethod == 'ISO_10918_1'
         assert ds['PixelData'].VR == 'OB'
-        assert ds['PixelData'].is_undefined_length == True
+        assert ds['PixelData'].is_undefined_length is True
 
     def test_compress_frame_to_jpeg_2d(self, manager_with_data):
         """Test _compress_frame_to_jpeg with 2D frame"""
@@ -963,8 +962,8 @@ class TestDicomFileManager:
         assert hasattr(ds, 'BitsAllocated')
         assert hasattr(ds, 'TransducerData')
 
-    def test_copy_source_metadata_excludes_station_name(self, manager_with_data, temp_dir):
-        """StationName (0008,1010) is a device/location identifier and must not leak to de-id"""
+    def test_copy_source_metadata_preserves_station_name(self, manager_with_data, temp_dir):
+        """StationName (0008,1010) is preserved in the de-id DICOM per institutional workflow"""
         ds = pydicom.Dataset()
         source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
         source_ds.StationName = "US_ROOM_3B"
@@ -972,10 +971,10 @@ class TestDicomFileManager:
 
         manager_with_data._copy_source_metadata(ds, source_ds, output_path)
 
-        assert not hasattr(ds, 'StationName')
+        assert ds.StationName == "US_ROOM_3B"
 
-    def test_copy_source_metadata_excludes_study_description(self, manager_with_data, temp_dir):
-        """StudyDescription is a free-text field that frequently contains PHI; must not leak"""
+    def test_copy_source_metadata_preserves_study_description(self, manager_with_data, temp_dir):
+        """StudyDescription is preserved in the de-id DICOM per institutional workflow"""
         ds = pydicom.Dataset()
         source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
         source_ds.StudyDescription = "Patient Jane Doe referred by Dr Smith"
@@ -983,7 +982,7 @@ class TestDicomFileManager:
 
         manager_with_data._copy_source_metadata(ds, source_ds, output_path)
 
-        assert not hasattr(ds, 'StudyDescription')
+        assert ds.StudyDescription == "Patient Jane Doe referred by Dr Smith"
 
     def test_apply_anonymization_caps_patient_age_over_89(self, manager_with_data):
         """PatientAge >= 90 years is capped at '090Y' per HIPAA Safe Harbor"""
@@ -1120,8 +1119,8 @@ class TestDicomFileManager:
         assert hasattr(ds, 'TransducerData')
         assert ds.TransducerData == ""
 
-    def test_copy_source_metadata_strips_transducer_data_serial(self, manager_with_data, temp_dir):
-        """TransducerData in de-id retains only the model segment, not the serial number"""
+    def test_copy_source_metadata_preserves_transducer_data_serial(self, manager_with_data, temp_dir):
+        """TransducerData in de-id retains the raw source value, including the serial segment"""
         ds = pydicom.Dataset()
         source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
         source_ds.TransducerData = "SC6-1s,JK9U41102597"
@@ -1129,10 +1128,10 @@ class TestDicomFileManager:
 
         manager_with_data._copy_source_metadata(ds, source_ds, output_path)
 
-        assert ds.TransducerData == "SC6-1s"
+        assert ds.TransducerData == "SC6-1s,JK9U41102597"
 
-    def test_copy_source_metadata_strips_transducer_data_backslash(self, manager_with_data, temp_dir):
-        """Backslash-delimited TransducerData is stripped to model segment only"""
+    def test_copy_source_metadata_preserves_transducer_data_backslash(self, manager_with_data, temp_dir):
+        """Backslash-delimited TransducerData is preserved element-wise in the de-id DICOM"""
         from pydicom.multival import MultiValue
         ds = pydicom.Dataset()
         source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
@@ -1141,7 +1140,7 @@ class TestDicomFileManager:
 
         manager_with_data._copy_source_metadata(ds, source_ds, output_path)
 
-        assert ds.TransducerData == "S4-1U"
+        assert list(ds.TransducerData) == ["S4-1U", "UNUSED", "UNUSED"]
 
     def test_copy_source_metadata_preserves_transducer_data_case(self, manager_with_data, temp_dir):
         """TransducerData model segment in de-id preserves original case (unlike TransducerModel DataFrame column)"""
@@ -1369,9 +1368,9 @@ class TestDicomFileManager:
         assert len(result) == 3
         assert all(isinstance(item, str) for item in result)
 
-    # Test for updated comment in _copy_and_generate_uids (verification that logic still works)
-    def test_copy_and_generate_uids_always_generates_series_uid(self, manager_with_data, temp_dir):
-        """Test that SeriesInstanceUID is always generated (never copied from source)"""
+    # Test that SeriesInstanceUID is now passed through from source
+    def test_copy_and_generate_uids_passes_through_series_uid(self, manager_with_data, temp_dir):
+        """Test that SeriesInstanceUID is copied from source when present"""
         ds = pydicom.Dataset()
         source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
         output_path = os.path.join(temp_dir, "test.dcm")
@@ -1380,8 +1379,16 @@ class TestDicomFileManager:
 
         manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
 
-        # SeriesInstanceUID should always be different from source
-        assert ds.SeriesInstanceUID != original_series_uid
+        assert ds.SeriesInstanceUID == original_series_uid
+
+    def test_copy_and_generate_uids_generates_series_uid_when_missing(self, manager_with_data, temp_dir):
+        """Test that SeriesInstanceUID is freshly generated when source lacks it"""
+        ds = pydicom.Dataset()
+        source_ds = pydicom.Dataset()  # empty — no SeriesInstanceUID
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
+
         assert hasattr(ds, 'SeriesInstanceUID')
         assert ds.SeriesInstanceUID != ""
 

--- a/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
@@ -208,16 +208,60 @@ class TestDicomFileManager:
         assert manager.next_index == 0
 
     def test_get_transducer_model_valid(self, manager):
-        """Test transducer model extraction with valid input"""
+        """Test transducer model extraction with valid comma-delimited input"""
         assert manager.get_transducer_model("SC6-1s,02597") == "sc6-1s"
         assert manager.get_transducer_model("L12-3,12345") == "l12-3"
         assert manager.get_transducer_model("C1-5") == "c1-5"
+        # Explicit non-Butterfly manufacturer arg should not change behavior
+        assert manager.get_transducer_model("SC6-1s,02597", manufacturer="Philips") == "sc6-1s"
 
     def test_get_transducer_model_invalid(self, manager):
         """Test transducer model extraction with invalid input"""
         assert manager.get_transducer_model("") == "unknown"
         assert manager.get_transducer_model(None) == "unknown"
         assert manager.get_transducer_model("   ") == "unknown"
+
+    def test_get_transducer_model_backslash_format(self, manager):
+        """Test backslash-delimited TransducerData (VR LO native separator)"""
+        assert manager.get_transducer_model("S4-1U\\UNUSED\\UNUSED") == "s4-1u"
+        assert manager.get_transducer_model("L12-3\\UNUSED") == "l12-3"
+
+    def test_get_transducer_model_backslash_multivalue(self, manager):
+        """Test pydicom MultiValue input (auto-split backslash-delimited LO)"""
+        from pydicom.multival import MultiValue
+        mv = MultiValue(str, ["S4-1U", "UNUSED", "UNUSED"])
+        assert manager.get_transducer_model(mv) == "s4-1u"
+
+    def test_get_transducer_model_butterfly_uses_model_name(self, manager):
+        """Test Butterfly manufacturer routes through ManufacturerModelName"""
+        assert manager.get_transducer_model(
+            "", manufacturer="Butterfly Network Inc", manufacturer_model_name="IQ"
+        ) == "iq"
+        # Butterfly branch ignores TransducerData even when present
+        assert manager.get_transducer_model(
+            "IgnoreMe,123", manufacturer="Butterfly Network Inc", manufacturer_model_name="IQ3"
+        ) == "iq3"
+
+    def test_get_transducer_model_butterfly_case_insensitive(self, manager):
+        """Test Butterfly detection is case-insensitive substring match"""
+        assert manager.get_transducer_model(
+            "", manufacturer="butterfly network", manufacturer_model_name="IQ"
+        ) == "iq"
+        assert manager.get_transducer_model(
+            "", manufacturer="BUTTERFLY NETWORK INC", manufacturer_model_name="IQ"
+        ) == "iq"
+        assert manager.get_transducer_model(
+            "", manufacturer="Butterfly Network Inc.", manufacturer_model_name="IQ"
+        ) == "iq"
+
+    def test_get_transducer_model_butterfly_missing_model_name(self, manager):
+        """Test Butterfly without ManufacturerModelName returns 'unknown' (no fallback)"""
+        assert manager.get_transducer_model(
+            "SC6-1s,02597", manufacturer="Butterfly Network Inc", manufacturer_model_name=""
+        ) == "unknown"
+        assert manager.get_transducer_model(
+            "SC6-1s,02597", manufacturer="Butterfly Network Inc", manufacturer_model_name=None
+        ) == "unknown"
 
     def test_get_number_of_instances_empty(self, manager):
         """Test get_number_of_instances with empty dataframe"""
@@ -270,6 +314,21 @@ class TestDicomFileManager:
         result = manager._extract_dicom_info(filepath, self.INPUT_FOLDER, False)
 
         assert result is None
+
+    def test_extract_dicom_info_butterfly(self, manager, temp_dir):
+        """Test Butterfly manufacturer DICOM uses ManufacturerModelName for TransducerModel"""
+        ds = self.create_test_dicom_file(
+            Manufacturer="Butterfly Network Inc",
+            ManufacturerModelName="IQ",
+            TransducerData="",
+        )
+        filename = manager._generate_filename_from_dicom(ds)
+        filepath = self.save_dicom_file(ds, temp_dir, filename)
+
+        result = manager._extract_dicom_info(filepath, self.INPUT_FOLDER, False)
+
+        assert result is not None
+        assert result['TransducerModel'] == "iq"
 
     def test_extract_dicom_info_includes_output_path(self, manager, temp_dir):
         # Create a subdirectory structure
@@ -902,6 +961,68 @@ class TestDicomFileManager:
         # But these should still be copied
         assert hasattr(ds, 'BitsAllocated')
         assert hasattr(ds, 'TransducerData')
+
+    def test_copy_source_metadata_preserves_transducer_type(self, manager_with_data, temp_dir):
+        """Test TransducerType present in source is preserved in de-id output"""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.TransducerType = "LINEAR"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert ds.TransducerType == "LINEAR"
+
+    def test_copy_source_metadata_blanks_missing_transducer_type(self, manager_with_data, temp_dir):
+        """Test TransducerType is present as empty string when absent in source"""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        if hasattr(source_ds, 'TransducerType'):
+            delattr(source_ds, 'TransducerType')
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert hasattr(ds, 'TransducerType')
+        assert ds.TransducerType == ""
+
+    def test_copy_source_metadata_blanks_missing_transducer_data(self, manager_with_data, temp_dir):
+        """Test TransducerData is present as empty string when absent in source"""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        if hasattr(source_ds, 'TransducerData'):
+            delattr(source_ds, 'TransducerData')
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert hasattr(ds, 'TransducerData')
+        assert ds.TransducerData == ""
+
+    def test_copy_source_metadata_blanks_missing_manufacturer_model_name(self, manager_with_data, temp_dir):
+        """Test ManufacturerModelName is present as empty string when absent in source"""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        if hasattr(source_ds, 'ManufacturerModelName'):
+            delattr(source_ds, 'ManufacturerModelName')
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert hasattr(ds, 'ManufacturerModelName')
+        assert ds.ManufacturerModelName == ""
+
+    def test_copy_source_metadata_preserves_empty_transducer_data(self, manager_with_data, temp_dir):
+        """Test TransducerData empty string in source is preserved as empty in de-id"""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.TransducerData = ""
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert hasattr(ds, 'TransducerData')
+        assert ds.TransducerData == ""
 
     def test_apply_anonymization_generates_uids_when_none_provided(self, manager_with_data):
         """Test that _apply_anonymization generates UIDs when no patient info provided"""

--- a/AnonymizeUltrasound/scripts/README.md
+++ b/AnonymizeUltrasound/scripts/README.md
@@ -153,7 +153,7 @@ python -m auto_anonymize \
 - **Patient name/ID:** Cleared or hashed (SHA-256)
 - **Birth date:** Truncated to year only
 - **Dates:** Randomly shifted ≤30 days (consistent per patient)
-- **UIDs:** Fresh SeriesInstanceUID generated
+- **UIDs:** SOP/Study/SeriesInstanceUID passed through from source when present; fresh UIDs generated only if missing
 - **Encoding:** Re-encoded with JPEG baseline compression
 
 #### Exit Codes


### PR DESCRIPTION
## Summary

Adds transducer-data extraction and refines metadata preservation in the de-id DICOM pipeline. Extracts the transducer model from `TransducerData` for downstream use, passes through `SeriesInstanceUID`, and preserves institutional tags (`StationName`, `StudyDescription`) and raw `TransducerData` in the anonymized output.

## Background: de-id policy trajectory

This branch went through two policy phases. Reviewers should note that the current state reflects the second phase, which walks back parts of the first.

**Phase 1 — stricter de-id** (commits `d1f157f`, `06b79ff`):
- `StationName` and `StudyDescription` removed from the tag-copy list, citing HIPAA Safe Harbor (device/room identifier; free-text field that may contain PHI).
- `TransducerData` stripped to the model segment only (removing the serial-number portion).
- `PatientAge` capped at `"090Y"` for ages ≥ 90.

**Phase 2 — restore pass-through for institutional workflow** (commit `72b5706`):
- `StationName` and `StudyDescription` restored to the tag-copy list.
- `TransducerData` preserved as the raw source value (model + serial).
- `SeriesInstanceUID` passed through from source instead of being regenerated.

The `PatientAge ≥ 90 → "090Y"` cap from Phase 1 is **not** reversed and remains in effect.

## What changes (current diff vs. `main`)

**New behavior**
- `TransducerData` parsing recognizes both backslash-delimited multi-value and comma-delimited single-value forms; the model segment is extracted for the DataFrame's `TransducerModel` column.
- `SeriesInstanceUID` is copied from source when present; a fresh UID is generated only when the source lacks one. Matches the existing `SOPInstanceUID` / `StudyInstanceUID` pattern.
- `PatientAge ≥ 90` years is capped at `"090Y"`; malformed values are logged and passed through unchanged.

**Metadata copied to de-id output**
- `TransducerData` — raw source value (preserved element-wise for multi-value form)
- `StationName`, `StudyDescription` — copied when present
- `BitsAllocated`, `BitsStored`, `Rows`, `Columns`, `PatientSex`, `PixelRepresentation`, `SeriesNumber`, `StudyDate`, `StudyTime`, `Manufacturer` — copied when present

**UID handling in de-id output**
- `SOPClassUID`, `SOPInstanceUID`, `StudyInstanceUID`, `SeriesInstanceUID` — all four now follow the same copy-or-generate pattern: pass through from source if present, otherwise log an error and generate a fresh UID.

**Quality changes**
- Pixel-data decode fallbacks now log the exception cause before transitioning (previously silent).
- Six pre-existing ruff findings cleaned up (unused import, redundant f-prefix, `is True`/`is False` for strict-bool assertions).

## Test plan

- [x] Unit tests pass: `uv run pytest AnonymizeUltrasound/common/tests/test_dicom_file_manager.py -q`
- [x] Ruff clean: `ruff check AnonymizeUltrasound/common/dicom_file_manager.py AnonymizeUltrasound/common/tests/test_dicom_file_manager.py`
- [x] Anonymize a sample multi-frame DICOM via the existing CLI/Slicer flow; confirm on the output:
  - `SOPInstanceUID`, `SeriesInstanceUID`, `StudyInstanceUID` match the source
  - `TransducerData` matches the source (including serial segment)
  - `StationName`, `StudyDescription` match the source when present
  - `PatientAge == "090Y"` when source age ≥ 90