### PR TITLE
Write InputPath relative to input folder in keys.csv

### DIFF
--- a/AnonymizeUltrasound/AnonymizeUltrasound.py
+++ b/AnonymizeUltrasound/AnonymizeUltrasound.py
@@ -852,9 +852,9 @@ class AnonymizeUltrasoundWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             self._parameterNode.status = AnonymizerStatus.INITIAL
 
         # Export self.logic.dicom_manager.dicom_df as a CSV file in the headers directory
-        if self.logic.dicom_manager.dicom_df is not None and not self.logic.dicom_manager.dicom_df.empty:
-            outputFilePath = os.path.join(outputHeadersDirectory, "keys.csv")
-            self.logic.dicom_manager.dicom_df.drop(columns=['DICOMDataset'], inplace=False).to_csv(outputFilePath, index=False)
+        df = self.logic.dicom_manager.build_csv_dataframe(inputDirectory)
+        if df is not None:
+            df.to_csv(os.path.join(outputHeadersDirectory, "keys.csv"), index=False)
 
         statusText = str(numFiles)
         if self.ui.skipSingleframeCheckBox.checked:
@@ -2647,6 +2647,20 @@ class AnonymizeUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin)
             "overview_pdf_path": overview_pdf_path
         }
 
+    def _write_keys_csv(self, headers_directory: str, input_folder: str) -> None:
+        """Serialize dicom_df to <headers_directory>/keys.csv.
+
+        InputPath column is rewritten relative to input_folder. No-op if
+        headers_directory is empty or dicom_df is empty/None.
+        """
+        if not headers_directory:
+            return
+        df = self.dicom_manager.build_csv_dataframe(input_folder)
+        if df is None:
+            return
+        os.makedirs(headers_directory, exist_ok=True)
+        df.to_csv(os.path.join(headers_directory, "keys.csv"), index=False)
+
     def batch_auto_anonymize(self, input_folder: str, output_folder: str, headers_folder: str,
                             model_path: str = MODEL_PATH, device: str = "", **kwargs) -> Dict[str, Any]:
         start_time = time.time()
@@ -2676,10 +2690,7 @@ class AnonymizeUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin)
         num_files = self.dicom_manager.scan_directory(input_folder, config.skip_single_frame, config.hash_patient_id)
 
         # Save keys.csv
-        if self.dicom_manager.dicom_df is not None and headers_folder:
-            df = self.dicom_manager.dicom_df.drop(columns=['DICOMDataset'], inplace=False)
-            os.makedirs(headers_folder, exist_ok=True)
-            df.to_csv(os.path.join(headers_folder, "keys.csv"), index=False)
+        self._write_keys_csv(headers_folder, input_folder)
 
         overview_manifest = []
         overview_generator = OverviewGenerator(headers_folder)

--- a/AnonymizeUltrasound/common/dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/dicom_file_manager.py
@@ -168,6 +168,29 @@ class DicomFileManager:
         """Get number of instances in dataframe"""
         return len(self.dicom_df) if self.dicom_df is not None else 0
 
+    def build_csv_dataframe(self, input_folder: Optional[str]) -> Optional[pd.DataFrame]:
+        """Return a copy of dicom_df ready to serialize to keys.csv.
+
+        Drops the DICOMDataset column (binary payload, not CSV-serializable) and
+        rewrites InputPath from absolute filepath to relative-to-input_folder.
+        Leaves OutputPath and all other columns untouched.
+
+        Args:
+            input_folder: Root to compute InputPath relative to. If falsy,
+                InputPath is left unchanged (absolute).
+        Returns:
+            DataFrame ready for to_csv(), or None if dicom_df is None or empty.
+        """
+        if self.dicom_df is None or self.dicom_df.empty:
+            return None
+        df = self.dicom_df.drop(columns=['DICOMDataset'], inplace=False, errors='ignore')
+        if input_folder:
+            normed = os.path.normpath(input_folder)
+            df['InputPath'] = df['InputPath'].apply(
+                lambda p: os.path.relpath(p, normed) if isinstance(p, str) and p else p
+            )
+        return df
+
     def _extract_dicom_info(self, file_path: str, input_folder: str, skip_single_frame: bool, hash_patient_id: bool = True) -> Optional[dict]:
         """Extract DICOM information from file
 

--- a/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
@@ -1676,5 +1676,106 @@ class TestDicomFileManager:
         assert ds.PatientName == ""
         assert ds.PatientID == ""
 
+
+class TestBuildCsvDataframe:
+    """Tests for DicomFileManager.build_csv_dataframe.
+
+    The helper prepares dicom_df for keys.csv serialization: drops the
+    DICOMDataset binary column and rewrites InputPath relative to the given
+    input_folder. Internal dicom_df must NOT be mutated.
+    """
+
+    ROOT = os.path.normpath('/root')
+
+    @pytest.fixture
+    def manager(self):
+        return DicomFileManager()
+
+    def _make_row(self, input_path, output_path='anon.dcm'):
+        return {
+            'InputPath': input_path,
+            'OutputPath': output_path,
+            'AnonFilename': 'anon.dcm',
+            'PatientUID': 'P1',
+            'StudyUID': 'S1',
+            'SeriesUID': 'Se1',
+            'InstanceUID': 'I1',
+            'PhysicalDeltaX': 0.1,
+            'PhysicalDeltaY': 0.1,
+            'ContentDate': '20240101',
+            'ContentTime': '000000',
+            'Patch': False,
+            'TransducerModel': 'tm',
+            'DICOMDataset': object(),
+        }
+
+    def _populate(self, manager, rows):
+        manager.dicom_df = pd.DataFrame(rows, columns=DicomFileManager.DICOM_DATAFRAME_COLUMNS)
+
+    def test_rewrites_input_path_to_relative(self, manager):
+        abs_path = os.path.join(self.ROOT, 'a', 'b', 'IM001.dcm')
+        self._populate(manager, [self._make_row(abs_path)])
+
+        df = manager.build_csv_dataframe(self.ROOT)
+
+        assert df.iloc[0]['InputPath'] == os.path.join('a', 'b', 'IM001.dcm')
+
+    def test_preserves_nested_subdirs(self, manager):
+        abs_path = os.path.join(self.ROOT, 'p1', 's1', 'sub', 'IM001.dcm')
+        self._populate(manager, [self._make_row(abs_path)])
+
+        df = manager.build_csv_dataframe(self.ROOT)
+
+        assert df.iloc[0]['InputPath'] == os.path.join('p1', 's1', 'sub', 'IM001.dcm')
+
+    def test_drops_dicomdataset_column(self, manager):
+        abs_path = os.path.join(self.ROOT, 'a', 'IM001.dcm')
+        self._populate(manager, [self._make_row(abs_path)])
+
+        df = manager.build_csv_dataframe(self.ROOT)
+
+        assert 'DICOMDataset' not in df.columns
+        for col in ('InputPath', 'OutputPath', 'AnonFilename', 'PatientUID'):
+            assert col in df.columns
+
+    def test_preserves_output_path_unchanged(self, manager):
+        abs_path = os.path.join(self.ROOT, 'a', 'IM001.dcm')
+        self._populate(manager, [self._make_row(abs_path, output_path='a/anon_123.dcm')])
+
+        df = manager.build_csv_dataframe(self.ROOT)
+
+        assert df.iloc[0]['OutputPath'] == 'a/anon_123.dcm'
+        assert df.iloc[0]['OutputPath'] == manager.dicom_df.iloc[0]['OutputPath']
+
+    def test_returns_none_for_empty_df(self, manager):
+        manager.dicom_df = pd.DataFrame()
+
+        assert manager.build_csv_dataframe(self.ROOT) is None
+
+    def test_returns_none_when_df_is_none(self, manager):
+        manager.dicom_df = None
+
+        assert manager.build_csv_dataframe(self.ROOT) is None
+
+    def test_no_root_leaves_input_path_absolute(self, manager):
+        abs_path = os.path.join(self.ROOT, 'a', 'IM001.dcm')
+        self._populate(manager, [self._make_row(abs_path)])
+
+        df_none = manager.build_csv_dataframe(None)
+        df_empty = manager.build_csv_dataframe('')
+
+        assert df_none.iloc[0]['InputPath'] == abs_path
+        assert df_empty.iloc[0]['InputPath'] == abs_path
+
+    def test_handles_trailing_slash_in_input_folder(self, manager):
+        abs_path = os.path.join(self.ROOT, 'a', 'IM001.dcm')
+        self._populate(manager, [self._make_row(abs_path)])
+
+        df_slash = manager.build_csv_dataframe(self.ROOT + os.sep)
+        df_no_slash = manager.build_csv_dataframe(self.ROOT)
+
+        assert df_slash.iloc[0]['InputPath'] == df_no_slash.iloc[0]['InputPath']
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/AnonymizeUltrasound/scripts/auto_anonymize.py
+++ b/AnonymizeUltrasound/scripts/auto_anonymize.py
@@ -126,11 +126,11 @@ def main():
     logger.info(f"Found {num_files} DICOM files")
 
     # Save keys.csv
-    if dicom_manager.dicom_df is not None and args.headers_dir:
-        os.makedirs(args.headers_dir, exist_ok=True)
-        dicom_manager.dicom_df.drop(columns=['DICOMDataset'], inplace=False).to_csv(
-            os.path.join(args.headers_dir, 'keys.csv'), index=False
-        )
+    if args.headers_dir:
+        df = dicom_manager.build_csv_dataframe(args.input_dir)
+        if df is not None:
+            os.makedirs(args.headers_dir, exist_ok=True)
+            df.to_csv(os.path.join(args.headers_dir, 'keys.csv'), index=False)
 
     # Process files
     progress_reporter.start(num_files, f"Auto-anonymizing {args.model_path.split('/')[-1]} on {args.device} for {num_files} files...")


### PR DESCRIPTION
## Summary

- `keys.csv` now writes `InputPath` relative to the Input Folder instead of absolute filesystem paths, matching the existing relative format of `OutputPath` and making the CSV portable across machines.
- New helper `DicomFileManager.build_csv_dataframe(input_folder)` centralizes the `DICOMDataset` column drop and `InputPath` rewrite. Internal `dicom_df` storage stays absolute so file-reading code paths are unchanged.
- Widget `onImportDicomButton`, `AnonymizeUltrasoundLogic.batch_auto_anonymize` (via a new `_write_keys_csv` helper), and the `auto_anonymize.py` CLI all route through the new helper.

## Test plan

- [x] 8 new unit tests in `TestBuildCsvDataframe` cover: rewrite to relative, nested subdirs, DICOMDataset column drop, OutputPath preservation, empty/None dataframes, falsy root leaves absolute, trailing-slash normalization.
- [x] `uv run pytest AnonymizeUltrasound/common/tests -q` — 126 passed, 0 regressions.
- [x] Manual smoketest: run `python AnonymizeUltrasound/scripts/auto_anonymize.py --input_dir <sample> --output_dir <out> --headers_dir <hdr> --model_path <model>` on a small sample and visually confirm `<hdr>/keys.csv` shows relative InputPath values. Alternatively, use the Slicer App to verify results