### PR TITLE
Add deterministic UID remap and update de-id field handling

### DIFF
--- a/AnonymizeUltrasound/AnonymizeUltrasound.py
+++ b/AnonymizeUltrasound/AnonymizeUltrasound.py
@@ -2307,13 +2307,16 @@ class AnonymizeUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin)
     def saveDicomFile(self, dicomFilePath, new_patient_name='', new_patient_id='', labels=None):
         """
         Save the current ultrasound sequence as an anonymized DICOM file.
+
+        Returns the in-memory anonymized pydicom.Dataset so the header sidecar
+        in exportDicom() can serialize from it (preventing source UID leaks).
         """
         parameterNode = self.getParameterNode()
 
         # Collect image data from sequence browser as a numpy array
         image_array = self._collect_image_data_from_sequence(parameterNode)
 
-        self.dicom_manager.save_anonymized_dicom(
+        return self.dicom_manager.save_anonymized_dicom(
             image_array=image_array,
             output_path=dicomFilePath,
             new_patient_name=new_patient_name,
@@ -2381,11 +2384,12 @@ class AnonymizeUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin)
             - Saves sequence information and annotations to JSON file
             - Optionally saves original DICOM headers with partial anonymization
         """
-        # Record sequence information to a dictionary. This will be saved in the annotations JSON file.
+        # Record sequence information to a dictionary. This will be saved in the
+        # annotations JSON file. SOPInstanceUID is the anonymized UID
+        # (AnonSOPInstanceUID column populated at scan time); reading from
+        # DICOMDataset would leak the source UID into the sidecar.
         current_dicom_record = self.dicom_manager.dicom_df.iloc[self.dicom_manager.current_index]
-        SOPInstanceUID = current_dicom_record.DICOMDataset.SOPInstanceUID if current_dicom_record is not None else "None"
-        if SOPInstanceUID is None:
-            SOPInstanceUID = "None"
+        SOPInstanceUID = getattr(current_dicom_record, 'AnonSOPInstanceUID', '') or 'None'
 
         sequence_info = {
             'SOPInstanceUID': SOPInstanceUID,
@@ -2407,10 +2411,18 @@ class AnonymizeUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin)
         dicom_file_path = self.dicom_manager.generate_output_filepath(
             output_directory, current_dicom_record.OutputPath, preserve_directory_structure)
 
-        self.saveDicomFile(dicom_file_path, new_patient_name, new_patient_id, labels)
+        anonymized_ds = self.saveDicomFile(dicom_file_path, new_patient_name, new_patient_id, labels)
 
-        # Save original DICOM header to a json file. This may not be completely anonymized.
-        dicom_header_file_path = self.dicom_manager.save_anonymized_dicom_header(current_dicom_record, output_filename, headers_directory)
+        # Save DICOM header JSON, serializing from the in-memory anonymized
+        # Dataset so the sidecar contains only remapped UIDs and trimmed
+        # TransducerData — never the original source values.
+        if anonymized_ds is not None:
+            dicom_header_file_path = self.dicom_manager.save_anonymized_dicom_header(
+                current_dicom_record, output_filename, headers_directory,
+                anonymized_dataset=anonymized_ds,
+            )
+        else:
+            dicom_header_file_path = None
 
         # Add mask parameters to sequenceInfo
         for key, value in self.maskParameters.items():
@@ -2686,8 +2698,20 @@ class AnonymizeUltrasoundLogic(ScriptedLoadableModuleLogic, VTKObservationMixin)
         processor = DicomProcessor(config, self.dicom_manager)
         processor.initialize_model()
 
-        # Scan directory
-        num_files = self.dicom_manager.scan_directory(input_folder, config.skip_single_frame, config.hash_patient_id)
+        # Scan directory. Resume safety: when headers_folder already has a
+        # keys.csv from a prior batch run, seed scan_directory with it so the
+        # anonymized FrameOfReferenceUID mapping is preserved across the
+        # resumed export. Otherwise previously-written .dcm files and the
+        # rewritten keys.csv would disagree.
+        prior_keys_csv = None
+        if headers_folder:
+            candidate = os.path.join(headers_folder, 'keys.csv')
+            if os.path.exists(candidate):
+                prior_keys_csv = candidate
+        num_files = self.dicom_manager.scan_directory(
+            input_folder, config.skip_single_frame, config.hash_patient_id,
+            seed_keys_csv=prior_keys_csv,
+        )
 
         # Save keys.csv
         self._write_keys_csv(headers_folder, input_folder)

--- a/AnonymizeUltrasound/CMakeLists.txt
+++ b/AnonymizeUltrasound/CMakeLists.txt
@@ -13,6 +13,7 @@ set(MODULE_PYTHON_SCRIPTS
   common/masking.py
   common/overview_generator.py
   common/progress_reporter.py
+  common/uid_remap.py
   )
 
 set(MODULE_PYTHON_RESOURCES

--- a/AnonymizeUltrasound/common/dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/dicom_file_manager.py
@@ -632,11 +632,12 @@ class DicomFileManager:
         SOP Instance UIDs are routed through remap_uid so the de-id output sits
         in the 2.25 OID arc and original UIDs do not leak.
 
-        FrameOfReferenceUID is remapped (not generated) when present so spatial
-        linkage between de-id'd datasets in 3D/4D ultrasound and registration
-        workflows is preserved. When the source lacks it, the output is left
-        without one — inventing a synthetic frame UID would falsely link
-        otherwise-unrelated datasets.
+        FrameOfReferenceUID is regenerated from the already-remapped
+        SeriesInstanceUID. The source FOR UID is never read: copying or hashing
+        it would let recipients cluster de-id'd studies that shared a coordinate
+        system. Deriving from ds.SeriesInstanceUID keeps all instances in the
+        same de-id'd series sharing one coordinate UID (Type 1/1C compliance for
+        US IODs and intra-series spatial linkage) without leaking the source.
         """
         if hasattr(source_ds, 'SOPClassUID') and source_ds.SOPClassUID:
             ds.SOPClassUID = source_ds.SOPClassUID
@@ -652,10 +653,7 @@ class DicomFileManager:
                 logging.error(f"{attr} not found. Generating new one for {output_path}")
                 setattr(ds, attr, remap_uid(pydicom.uid.generate_uid()))
 
-        # FrameOfReferenceUID is conditional: remap if present, omit otherwise.
-        src_for_uid = getattr(source_ds, 'FrameOfReferenceUID', None)
-        if src_for_uid:
-            ds.FrameOfReferenceUID = remap_uid(str(src_for_uid))
+        ds.FrameOfReferenceUID = remap_uid(str(ds.SeriesInstanceUID))
 
     def _apply_anonymization(self, ds: pydicom.Dataset, source_ds: pydicom.Dataset,
                             new_patient_name: str = "", new_patient_id: str = "") -> None:

--- a/AnonymizeUltrasound/common/dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/dicom_file_manager.py
@@ -78,6 +78,8 @@ class DicomFileManager:
         'AnonStudyUID',
         'AnonSeriesUID',
         'AnonSOPInstanceUID',
+        'FrameOfReferenceUID',
+        'AnonFrameOfReferenceUID',
         'PhysicalDeltaX',
         'PhysicalDeltaY',
         'ContentDate',
@@ -97,6 +99,10 @@ class DicomFileManager:
         self.input_folder = None
         self.next_index = 0
         self.current_index = 0
+        # Maps (source StudyInstanceUID, source FrameOfReferenceUID) → run-local
+        # anonymized FOR UID. Populated by _populate_anon_for_column or seeded
+        # from a prior export's keys.csv via _seed_for_map_from_keys_csv.
+        self._for_map: dict[tuple[str, str], str] = {}
 
     def _first_transducer_segment(self, raw) -> str:
         """Return the first segment of a TransducerData-like value with case preserved.
@@ -135,7 +141,9 @@ class DicomFileManager:
         segment = self._first_transducer_segment(raw)
         return segment.lower() if segment else 'unknown'
 
-    def scan_directory(self, input_folder: str, skip_single_frame: bool = False, hash_patient_id: bool = True) -> int:
+    def scan_directory(self, input_folder: str, skip_single_frame: bool = False,
+                       hash_patient_id: bool = True,
+                       seed_keys_csv: Optional[str] = None) -> int:
         """
         Scan directory for DICOM files and create dataframe
 
@@ -143,11 +151,19 @@ class DicomFileManager:
             input_folder: Directory to scan
             skip_single_frame: Skip single frame DICOM files (AnonymizeUltrasound)
             hash_patient_id: If True, hash the patient ID
+            seed_keys_csv: Optional path to a prior export's keys.csv. When
+                provided, the (StudyUID, source FOR) → AnonFrameOfReferenceUID
+                mapping from that file pre-populates self._for_map so a resumed
+                export reuses the same anon FOR UIDs as the prior partial run.
 
         Returns:
             Number of DICOM files found
         """
         dicom_data = []
+
+        # Seed _for_map BEFORE _create_dataframe assigns the column, so seeded
+        # mappings are consulted instead of regenerated.
+        self._seed_for_map_from_keys_csv(seed_keys_csv)
 
         for root, dirs, files in os.walk(input_folder):
             # Sort to ensure consistent processing order
@@ -167,6 +183,34 @@ class DicomFileManager:
         self._create_dataframe(dicom_data)
 
         return len(self.dicom_df) if self.dicom_df is not None else 0
+
+    def _seed_for_map_from_keys_csv(self, path: Optional[str]) -> None:
+        """Pre-populate self._for_map from an existing export's keys.csv.
+
+        Enables resume safety: skipped + newly written files in a resumed export
+        share one (StudyUID, source FOR) → AnonFrameOfReferenceUID mapping.
+        Silently no-ops if path is None/empty/missing or the keys.csv lacks the
+        FrameOfReferenceUID / AnonFrameOfReferenceUID columns (older export
+        pre-dating this change). Existing entries in self._for_map are not
+        overwritten — first-seen wins (use setdefault).
+        """
+        if not path or not os.path.exists(path):
+            return
+        prior = pd.read_csv(path, dtype=str).fillna('')
+        required = {'StudyUID', 'FrameOfReferenceUID', 'AnonFrameOfReferenceUID'}
+        if not required.issubset(prior.columns):
+            return
+        for _, row in prior.iterrows():
+            study = row['StudyUID']
+            source_for = row['FrameOfReferenceUID']
+            anon = row['AnonFrameOfReferenceUID']
+            if not (study and anon):
+                continue
+            if source_for:
+                key = (study, source_for)
+            else:
+                key = (study, f":SeriesUID:{row.get('SeriesUID', '')}")
+            self._for_map.setdefault(key, anon)
 
     def get_number_of_instances(self) -> int:
         """Get number of instances in dataframe"""
@@ -260,6 +304,7 @@ class DicomFileManager:
                 'AnonStudyUID': remap_uid(str(study_uid)) if study_uid else '',
                 'AnonSeriesUID': remap_uid(str(series_uid)) if series_uid else '',
                 'AnonSOPInstanceUID': remap_uid(str(instance_uid)) if instance_uid else '',
+                'FrameOfReferenceUID': getattr(dicom_ds, 'FrameOfReferenceUID', ''),
                 'PhysicalDeltaX': physical_delta_x,
                 'PhysicalDeltaY': physical_delta_y,
                 'ContentDate': content_date,
@@ -375,7 +420,41 @@ class DicomFileManager:
                                        .groupby('StudyUID')[spacing_cols]
                                        .transform(lambda x: x.ffill().bfill()))
 
+        # Populate AnonFrameOfReferenceUID per (StudyUID, source FOR) group using
+        # the run-local _for_map (possibly seeded from a prior keys.csv).
+        self._populate_anon_for_column()
+
         self.next_index = 0
+
+    def _populate_anon_for_column(self) -> None:
+        """Assign AnonFrameOfReferenceUID per (StudyUID, source FrameOfReferenceUID) group.
+
+        Uses self._for_map as the source of truth. Reuses entries already in the
+        map (populated by _seed_for_map_from_keys_csv on resume). Generates fresh
+        pydicom.uid.generate_uid(prefix=None) values for new groups, yielding
+        run-local 2.25-arc UIDs.
+
+        For rows whose source dataset lacks a FrameOfReferenceUID, the mapping
+        key falls back to (StudyUID, ":SeriesUID:" + SeriesUID) so coordinate-less
+        series within one study are NOT falsely linked to one another. Real DICOM
+        UIDs contain only digits and dots, so the ":SeriesUID:" infix cannot
+        collide with a real-FOR-derived key.
+        """
+        if self.dicom_df is None or self.dicom_df.empty:
+            return
+
+        def assign(row):
+            study = str(row['StudyUID'])
+            source_for = str(row.get('FrameOfReferenceUID') or '')
+            if source_for:
+                key = (study, source_for)
+            else:
+                key = (study, f":SeriesUID:{row['SeriesUID']}")
+            if key not in self._for_map:
+                self._for_map[key] = pydicom.uid.generate_uid(prefix=None)
+            return self._for_map[key]
+
+        self.dicom_df['AnonFrameOfReferenceUID'] = self.dicom_df.apply(assign, axis=1)
 
     def update_progress_from_output(self, output_directory: str, preserve_directory_structure: bool) -> Optional[int]:
         """Update progress based on existing output files
@@ -625,19 +704,36 @@ class DicomFileManager:
         ds.SeriesNumber = self._get_series_number_for_current_instance()
 
     def _copy_and_generate_uids(self, ds: pydicom.Dataset, source_ds: pydicom.Dataset, output_path: str) -> None:
-        """Remap instance UIDs deterministically; preserve SOPClassUID verbatim.
+        """Remap instance UIDs deterministically; assign a run-local per-study FOR UID.
 
         SOPClassUID identifies the registered DICOM object type (e.g. Ultrasound
         Multi-frame Image Storage) and must NOT be remapped. Study, Series, and
         SOP Instance UIDs are routed through remap_uid so the de-id output sits
         in the 2.25 OID arc and original UIDs do not leak.
 
-        FrameOfReferenceUID is regenerated from the already-remapped
-        SeriesInstanceUID. The source FOR UID is never read: copying or hashing
-        it would let recipients cluster de-id'd studies that shared a coordinate
-        system. Deriving from ds.SeriesInstanceUID keeps all instances in the
-        same de-id'd series sharing one coordinate UID (Type 1/1C compliance for
-        US IODs and intra-series spatial linkage) without leaking the source.
+        FrameOfReferenceUID is assigned per (source StudyInstanceUID, source
+        FrameOfReferenceUID) group and is generated run-locally — two separate
+        de-id runs over the same source data produce different output FORs, so
+        recipients cannot cluster de-id'd studies across exports. Within a single
+        run, two source series in one study that legitimately shared a FOR UID
+        get the SAME output FOR UID so downstream multi-series registration /
+        volumetric fusion keeps working. Coordinate-less source series within
+        one study get distinct output FOR UIDs (no false linkage).
+
+        Resume contract: when scan_directory is called with seed_keys_csv, the
+        prior export's (StudyUID, source FOR) → AnonFrameOfReferenceUID rows
+        seed self._for_map, so a resumed export reuses the prior anon FORs for
+        already-written files while minting fresh ones for new pairs.
+
+        Three-tier read path for the output FOR UID:
+          1. Primary — self.dicom_df.iloc[current_index]['AnonFrameOfReferenceUID']
+             (the precomputed column populated by _populate_anon_for_column).
+          2. Fallback — self._for_map.get((StudyUID, source FOR or
+             ":SeriesUID:<series>" sentinel)). Used by direct callers that
+             bypass scan_directory.
+          3. Last resort — mint a fresh pydicom.uid.generate_uid(prefix=None)
+             and log an error (indicates a bug; should not happen in normal
+             scan_directory flows).
         """
         if hasattr(source_ds, 'SOPClassUID') and source_ds.SOPClassUID:
             ds.SOPClassUID = source_ds.SOPClassUID
@@ -653,7 +749,40 @@ class DicomFileManager:
                 logging.error(f"{attr} not found. Generating new one for {output_path}")
                 setattr(ds, attr, remap_uid(pydicom.uid.generate_uid()))
 
-        ds.FrameOfReferenceUID = remap_uid(str(ds.SeriesInstanceUID))
+        ds.FrameOfReferenceUID = self._resolve_anon_for_uid(source_ds, output_path)
+
+    def _resolve_anon_for_uid(self, source_ds: pydicom.Dataset, output_path: str) -> str:
+        """Resolve the anonymized FOR UID via the three-tier read path.
+
+        See _copy_and_generate_uids docstring for the policy. Split out so the
+        read logic is exercised in isolation by the plumbing unit tests.
+        """
+        # Tier 1: dataframe column.
+        if (self.dicom_df is not None
+                and 0 <= self.current_index < len(self.dicom_df)
+                and 'AnonFrameOfReferenceUID' in self.dicom_df.columns):
+            candidate = self.dicom_df.iloc[self.current_index]['AnonFrameOfReferenceUID']
+            if candidate:
+                return str(candidate)
+
+        # Tier 2: in-memory map keyed by source (StudyUID, FOR).
+        study_uid = getattr(source_ds, 'StudyInstanceUID', None)
+        source_for = getattr(source_ds, 'FrameOfReferenceUID', '') or ''
+        if study_uid:
+            if source_for:
+                key = (str(study_uid), source_for)
+            else:
+                key = (str(study_uid),
+                       f":SeriesUID:{getattr(source_ds, 'SeriesInstanceUID', '')}")
+            mapped = self._for_map.get(key)
+            if mapped:
+                return mapped
+
+        # Tier 3: mint and log error — should not happen in normal flows.
+        logging.error(
+            f"AnonFrameOfReferenceUID not available; generating fallback for {output_path}"
+        )
+        return pydicom.uid.generate_uid(prefix=None)
 
     def _apply_anonymization(self, ds: pydicom.Dataset, source_ds: pydicom.Dataset,
                             new_patient_name: str = "", new_patient_id: str = "") -> None:

--- a/AnonymizeUltrasound/common/dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/dicom_file_manager.py
@@ -631,6 +631,12 @@ class DicomFileManager:
         Multi-frame Image Storage) and must NOT be remapped. Study, Series, and
         SOP Instance UIDs are routed through remap_uid so the de-id output sits
         in the 2.25 OID arc and original UIDs do not leak.
+
+        FrameOfReferenceUID is remapped (not generated) when present so spatial
+        linkage between de-id'd datasets in 3D/4D ultrasound and registration
+        workflows is preserved. When the source lacks it, the output is left
+        without one — inventing a synthetic frame UID would falsely link
+        otherwise-unrelated datasets.
         """
         if hasattr(source_ds, 'SOPClassUID') and source_ds.SOPClassUID:
             ds.SOPClassUID = source_ds.SOPClassUID
@@ -646,6 +652,11 @@ class DicomFileManager:
                 logging.error(f"{attr} not found. Generating new one for {output_path}")
                 setattr(ds, attr, remap_uid(pydicom.uid.generate_uid()))
 
+        # FrameOfReferenceUID is conditional: remap if present, omit otherwise.
+        src_for_uid = getattr(source_ds, 'FrameOfReferenceUID', None)
+        if src_for_uid:
+            ds.FrameOfReferenceUID = remap_uid(str(src_for_uid))
+
     def _apply_anonymization(self, ds: pydicom.Dataset, source_ds: pydicom.Dataset,
                             new_patient_name: str = "", new_patient_id: str = "") -> None:
         """Apply anonymization including patient info and date shifting."""
@@ -656,9 +667,15 @@ class DicomFileManager:
         ds.ReferringPhysicianName = ""
         ds.AccessionNumber = ""
 
-        # HIPAA Safe Harbor: aggregate ages >89 years to "090Y".
-        if hasattr(ds, 'PatientAge'):
+        # HIPAA Safe Harbor: aggregate ages >89 years to "090Y". When the
+        # source has no PatientAge, derive it from StudyDate - PatientBirthDate
+        # so the demographic survives de-id when only PatientBirthDate was set.
+        if hasattr(ds, 'PatientAge') and ds.PatientAge:
             ds.PatientAge = self._cap_patient_age(ds.PatientAge)
+        else:
+            computed = self._compute_patient_age_from_birthdate(source_ds)
+            if computed is not None:
+                ds.PatientAge = computed
 
         # Apply date shifting for anonymization
         self._apply_date_shifting(ds, source_ds)
@@ -692,6 +709,54 @@ class DicomFileManager:
 
         years = int(age_str[:3])
         return '090Y' if years >= 90 else age_str
+
+    def _compute_patient_age_from_birthdate(self, source_ds: pydicom.Dataset) -> Optional[str]:
+        """Compute DICOM AS PatientAge from source StudyDate - PatientBirthDate.
+
+        Used only when the source dataset has no PatientAge — trusts the source
+        value when present. Returns ``None`` (and logs a warning) if the math
+        can't be performed: missing/empty dates, malformed dates, or a birth
+        date after the study date. Output units are picked by the magnitude of
+        the delta to keep the value clinically meaningful:
+
+        * ``< 31 days``  -> ``nnnD``
+        * ``< 365 days`` -> ``nnnM`` using 30.4375 days/month
+        * else           -> ``nnnY`` using 365.25 days/year, capped at ``090Y``
+          per HIPAA Safe Harbor §164.514(b)(2)(i)(C).
+        """
+        study_date_str = getattr(source_ds, 'StudyDate', None)
+        birth_date_str = getattr(source_ds, 'PatientBirthDate', None)
+        if not study_date_str or not birth_date_str:
+            logging.warning(
+                "PatientAge not set: source has no usable PatientBirthDate+StudyDate"
+            )
+            return None
+
+        try:
+            study_date = datetime.datetime.strptime(str(study_date_str), "%Y%m%d")
+            birth_date = datetime.datetime.strptime(str(birth_date_str), "%Y%m%d")
+        except ValueError:
+            logging.warning(
+                f"PatientAge not set: could not parse PatientBirthDate={birth_date_str!r} "
+                f"or StudyDate={study_date_str!r} as %Y%m%d"
+            )
+            return None
+
+        if study_date < birth_date:
+            logging.warning(
+                "PatientAge not set: PatientBirthDate is after StudyDate "
+                f"(birth={birth_date_str}, study={study_date_str})"
+            )
+            return None
+
+        delta_days = (study_date - birth_date).days
+        if delta_days < 31:
+            return f"{delta_days:03d}D"
+        if delta_days < 365:
+            months = int(delta_days // 30.4375)
+            return f"{months:03d}M"
+        years = int(delta_days // 365.25)
+        return '090Y' if years >= 90 else f"{years:03d}Y"
 
     def _shift_date(self, date_str: str, offset: int) -> str:
         """Shift a single date by the given offset."""

--- a/AnonymizeUltrasound/common/dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/dicom_file_manager.py
@@ -161,8 +161,12 @@ class DicomFileManager:
         """
         dicom_data = []
 
-        # Seed _for_map BEFORE _create_dataframe assigns the column, so seeded
-        # mappings are consulted instead of regenerated.
+        # Reset _for_map before seeding so a long-lived DicomFileManager (e.g.
+        # the Slicer logic singleton) doesn't carry mappings between unrelated
+        # scans — that would re-use anonymized FOR UIDs across exports and
+        # break run-local unlinkability. Seeding uses setdefault, so the
+        # reset-then-seed order preserves the resume contract.
+        self._for_map = {}
         self._seed_for_map_from_keys_csv(seed_keys_csv)
 
         for root, dirs, files in os.walk(input_folder):
@@ -582,9 +586,14 @@ class DicomFileManager:
         return self.next_index < len(self.dicom_df)
 
     def save_anonymized_dicom(self, image_array: np.ndarray, output_path: str,
-                            new_patient_name: str = '', new_patient_id: str = '', labels: Optional[List[str]] = None) -> None:
+                            new_patient_name: str = '', new_patient_id: str = '', labels: Optional[List[str]] = None) -> Optional[pydicom.Dataset]:
         """
-        Save image array as anonymized DICOM file.
+        Save image array as anonymized DICOM file and return the in-memory anon Dataset.
+
+        The return value lets callers feed the same anonymized Dataset into
+        `save_anonymized_dicom_header`, so the JSON sidecar serializes from
+        the same source of truth as the saved .dcm — preventing source UIDs
+        and untrimmed TransducerData from leaking into the header file.
 
         Args:
             image_array: Numpy array containing image data (frames, height, width, channels)
@@ -592,18 +601,23 @@ class DicomFileManager:
             new_patient_name: New patient name for anonymization
             new_patient_id: New patient ID for anonymization
             labels: List of labels to add to the DICOM file
+
+        Returns:
+            The anonymized pydicom.Dataset on success, or None when the call
+            fails its pre-conditions (no dataframe, invalid current_index,
+            None image array).
         """
         if self.dicom_df is None:
             logging.error("No DICOM dataframe available")
-            return
+            return None
 
         if self.current_index >= len(self.dicom_df):
             logging.error("No current DICOM record available")
-            return
+            return None
 
         if image_array is None:
             logging.error("Image array is None")
-            return
+            return None
 
         current_record = self.dicom_df.iloc[self.current_index]
         source_dataset = current_record.DICOMDataset
@@ -629,6 +643,8 @@ class DicomFileManager:
 
         # Create and save file
         self._create_and_save_dicom_file(anonymized_ds, output_path)
+
+        return anonymized_ds
 
     def _create_base_dicom_dataset(self, image_array: np.ndarray, current_record: dict) -> pydicom.Dataset:
         """Create base DICOM dataset with image dimensions and basic attributes."""
@@ -882,7 +898,11 @@ class DicomFileManager:
         if delta_days < 365:
             months = int(delta_days // 30.4375)
             return f"{months:03d}M"
-        years = int(delta_days // 365.25)
+        # Calendar-year math avoids the int(365 // 365.25) == 0 boundary bug
+        # that would report a patient exactly one year old as "000Y".
+        years = study_date.year - birth_date.year
+        if (study_date.month, study_date.day) < (birth_date.month, birth_date.day):
+            years -= 1
         return '090Y' if years >= 90 else f"{years:03d}Y"
 
     def _shift_date(self, date_str: str, offset: int) -> str:
@@ -1051,37 +1071,55 @@ class DicomFileManager:
 
         return f"{patient_id}_{instance_id}.dcm", patient_id, instance_id
 
-    def save_anonymized_dicom_header(self, current_dicom_record, output_filename: str, headers_directory: Optional[str] = None) -> Optional[str]:
+    def save_anonymized_dicom_header(
+        self,
+        current_dicom_record,
+        output_filename: str,
+        headers_directory: Optional[str] = None,
+        *,
+        anonymized_dataset: pydicom.Dataset,
+    ) -> Optional[str]:
         """
         Save anonymized DICOM header information as a JSON file.
 
-        This method extracts DICOM header information from the current record,
-        applies partial anonymization to sensitive fields, and saves the result
-        as a JSON file alongside the anonymized DICOM file.
+        Serializes from `anonymized_dataset` — the in-memory Dataset returned
+        by `save_anonymized_dicom` — so the JSON sidecar contains the same
+        remapped UIDs, run-local FrameOfReferenceUID, and trimmed
+        TransducerData as the saved .dcm. Serializing from the source dataset
+        would leak the original UIDs and full TransducerData into the sidecar
+        next to an anonymized .dcm.
+
+        The patient-name override (using output_filename) and partial
+        birth-date scrub (keep year, set month/day to 01-01) are preserved
+        so the JSON's PatientName/PatientBirthDate columns stay consistent
+        across runs and don't expose the new_patient_id even when the anon
+        Dataset's PatientName is set to something else.
 
         Args:
-            current_dicom_record: Current DICOM record from the dataframe containing
-                                the DICOM dataset and metadata
-            headers_directory: Directory path where header JSON files will be saved.
-                            If None, no header file is created
-            output_filename: Base filename for the output (used for patient name anonymization)
+            current_dicom_record: Current DICOM record from the dataframe. Used
+                only for input validation (the dataset comes from
+                `anonymized_dataset`); retained so the kwarg contract matches
+                the long-standing call sites.
+            output_filename: Base filename for the output (drives PatientName
+                anonymization).
+            headers_directory: Directory path where header JSON files will be
+                saved. If None, no header file is created.
+            anonymized_dataset: The in-memory pydicom Dataset returned by
+                save_anonymized_dicom. Required; passing the source dataset
+                would defeat the de-id invariant.
 
         Returns:
-            str: Full path to the saved JSON header file
-            None: If headers_directory is None or saving fails
-
-        Note:
-            - Creates necessary output directories if they don't exist
-            - Applies partial anonymization to patient name and birth date
-            - Patient name is replaced with the output filename (without extension)
-            - Birth date is truncated to year only with "0101" appended
-            - Uses convertToJsonCompatible for handling DICOM-specific data types
+            str: Full path to the saved JSON header file.
+            None: If headers_directory is None.
         """
         if current_dicom_record is None:
             raise ValueError("Current DICOM record is required")
 
         if output_filename is None or output_filename == "":
             raise ValueError("Output filename is required")
+
+        if anonymized_dataset is None:
+            raise ValueError("anonymized_dataset is required to avoid source UID leak")
 
         if headers_directory is None:
             return None
@@ -1094,18 +1132,20 @@ class DicomFileManager:
         os.makedirs(os.path.dirname(dicom_header_filepath), exist_ok=True)
 
         with open(dicom_header_filepath, 'w') as outfile:
-            if self.dicom_df is not None:
-                anonymized_header = self.dicom_header_to_dict(current_dicom_record.DICOMDataset)
+            anonymized_header = self.dicom_header_to_dict(anonymized_dataset)
 
-                # Anonymize patient name
-                if "Patient's Name" in anonymized_header:
-                    anonymized_header["Patient's Name"] = output_filename.split(".")[0]
+            if "Patient's Name" in anonymized_header:
+                anonymized_header["Patient's Name"] = output_filename.split(".")[0]
 
-                # Partially anonymize birth date
-                if "Patient's Birth Date" in anonymized_header:
-                    anonymized_header["Patient's Birth Date"] = anonymized_header["Patient's Birth Date"][:4] + "0101"
+            # Partial birth-date scrub: source DS retains the original
+            # PatientBirthDate, so derive the year-only value from there.
+            source_birth = getattr(
+                current_dicom_record.DICOMDataset, 'PatientBirthDate', ''
+            ) or ''
+            if "Patient's Birth Date" in anonymized_header and source_birth:
+                anonymized_header["Patient's Birth Date"] = str(source_birth)[:4] + "0101"
 
-                json.dump(anonymized_header, outfile, default=self._convert_to_json_compatible)
+            json.dump(anonymized_header, outfile, default=self._convert_to_json_compatible)
 
         return dicom_header_filepath
 

--- a/AnonymizeUltrasound/common/dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/dicom_file_manager.py
@@ -12,6 +12,7 @@ import datetime
 import json
 from pydicom.dataset import FileMetaDataset
 from pydicom.encaps import generate_pixel_data_frame, decode_data_sequence
+from .uid_remap import remap_uid
 
 
 class DicomFileManager:
@@ -74,6 +75,9 @@ class DicomFileManager:
         'StudyUID',
         'SeriesUID',
         'InstanceUID',
+        'AnonStudyUID',
+        'AnonSeriesUID',
+        'AnonSOPInstanceUID',
         'PhysicalDeltaX',
         'PhysicalDeltaY',
         'ContentDate',
@@ -253,6 +257,9 @@ class DicomFileManager:
                 'StudyUID': study_uid,
                 'SeriesUID': series_uid,
                 'InstanceUID': instance_uid,
+                'AnonStudyUID': remap_uid(str(study_uid)) if study_uid else '',
+                'AnonSeriesUID': remap_uid(str(series_uid)) if series_uid else '',
+                'AnonSOPInstanceUID': remap_uid(str(instance_uid)) if instance_uid else '',
                 'PhysicalDeltaX': physical_delta_x,
                 'PhysicalDeltaY': physical_delta_y,
                 'ContentDate': content_date,
@@ -594,13 +601,21 @@ class DicomFileManager:
             ds.PixelSpacing = [f"{delta_x_mm:.14f}", f"{delta_y_mm:.14f}"]
 
     def _copy_source_metadata(self, ds: pydicom.Dataset, source_ds: pydicom.Dataset, output_path: str) -> None:
-        """Copy metadata from source dataset."""
+        """Copy metadata from source dataset.
+
+        TransducerData is reduced to its leading model segment (e.g. "SC6-1s")
+        so vendor serial numbers do not leak via 0018,5010. TransducerType and
+        ManufacturerModelName are preserved verbatim — downstream tooling and
+        Butterfly Network device routing depend on those exact values.
+        """
         for tag in self.DICOM_TAGS_TO_COPY:
             if hasattr(source_ds, tag):
                 setattr(ds, tag, getattr(source_ds, tag))
 
         for tag in self.DICOM_TAGS_PRESERVE_OR_BLANK:
             value = getattr(source_ds, tag, '') or ''
+            if tag == 'TransducerData':
+                value = self._first_transducer_segment(value)
             setattr(ds, tag, value)
 
         # Handle UIDs
@@ -610,36 +625,26 @@ class DicomFileManager:
         ds.SeriesNumber = self._get_series_number_for_current_instance()
 
     def _copy_and_generate_uids(self, ds: pydicom.Dataset, source_ds: pydicom.Dataset, output_path: str) -> None:
-        """Copy or generate required UIDs."""
-        # Copy or generate SOPClassUID
+        """Remap instance UIDs deterministically; preserve SOPClassUID verbatim.
+
+        SOPClassUID identifies the registered DICOM object type (e.g. Ultrasound
+        Multi-frame Image Storage) and must NOT be remapped. Study, Series, and
+        SOP Instance UIDs are routed through remap_uid so the de-id output sits
+        in the 2.25 OID arc and original UIDs do not leak.
+        """
         if hasattr(source_ds, 'SOPClassUID') and source_ds.SOPClassUID:
             ds.SOPClassUID = source_ds.SOPClassUID
         else:
             logging.error(f"SOPClassUID not found. Generating new one for {output_path}")
             ds.SOPClassUID = pydicom.uid.generate_uid()
 
-        # Copy or generate SOPInstanceUID
-        if hasattr(source_ds, 'SOPInstanceUID') and source_ds.SOPInstanceUID:
-            ds.SOPInstanceUID = source_ds.SOPInstanceUID
-        else:
-            logging.error(f"SOPInstanceUID not found. Generating new one for {output_path}")
-            ds.SOPInstanceUID = pydicom.uid.generate_uid()
-
-        # Copy or generate SeriesInstanceUID. Pass-through preserves series-level
-        # linkage between source and de-id outputs; callers must accept that
-        # ultrasound-machine UID reuse may cause viewer collisions downstream.
-        if hasattr(source_ds, 'SeriesInstanceUID') and source_ds.SeriesInstanceUID:
-            ds.SeriesInstanceUID = source_ds.SeriesInstanceUID
-        else:
-            logging.error(f"SeriesInstanceUID not found. Generating new one for {output_path}")
-            ds.SeriesInstanceUID = pydicom.uid.generate_uid()
-
-        # Copy or generate StudyInstanceUID
-        if hasattr(source_ds, 'StudyInstanceUID') and source_ds.StudyInstanceUID:
-            ds.StudyInstanceUID = source_ds.StudyInstanceUID
-        else:
-            logging.error(f"StudyInstanceUID not found. Generating new one for {output_path}")
-            ds.StudyInstanceUID = pydicom.uid.generate_uid()
+        for attr in ('SOPInstanceUID', 'SeriesInstanceUID', 'StudyInstanceUID'):
+            src_val = getattr(source_ds, attr, None)
+            if src_val:
+                setattr(ds, attr, remap_uid(str(src_val)))
+            else:
+                logging.error(f"{attr} not found. Generating new one for {output_path}")
+                setattr(ds, attr, remap_uid(pydicom.uid.generate_uid()))
 
     def _apply_anonymization(self, ds: pydicom.Dataset, source_ds: pydicom.Dataset,
                             new_patient_name: str = "", new_patient_id: str = "") -> None:

--- a/AnonymizeUltrasound/common/dicom_processor.py
+++ b/AnonymizeUltrasound/common/dicom_processor.py
@@ -302,7 +302,7 @@ class DicomProcessor:
             new_patient_id = anon_filename.split('_')[0]
 
             os.makedirs(os.path.dirname(final_output_path), exist_ok=True)
-            self.dicom_manager.save_anonymized_dicom(
+            anonymized_ds = self.dicom_manager.save_anonymized_dicom(
                 image_array=masked_image_array,
                 output_path=final_output_path,
                 new_patient_name=new_patient_name,
@@ -310,12 +310,15 @@ class DicomProcessor:
                 labels=None
             )
 
-            # Save header
-            if headers_folder:
+            # Save header — pass the anonymized Dataset so the JSON sidecar
+            # is serialized from the same source of truth as the saved .dcm
+            # (remapped UIDs, run-local FOR, trimmed TransducerData).
+            if headers_folder and anonymized_ds is not None:
                 self.dicom_manager.save_anonymized_dicom_header(
                     current_dicom_record=row,
                     output_filename=anon_filename,
-                    headers_directory=headers_folder
+                    headers_directory=headers_folder,
+                    anonymized_dataset=anonymized_ds,
                 )
 
             # Save sequence info JSON
@@ -630,10 +633,16 @@ class DicomProcessor:
 
 
     def _save_sequence_info(self, final_output_path: str, row, mask_config: Optional[dict]):
-        """Save sequence info JSON"""
+        """Save sequence info JSON.
+
+        SOPInstanceUID is the anonymized UID (row.AnonSOPInstanceUID, populated
+        in DicomFileManager._extract_dicom_info via remap_uid), not the source.
+        Reading from row.DICOMDataset would leak the original UID into the
+        sidecar next to an anonymized .dcm.
+        """
         if not self.config.no_mask_generation and not self.config.phi_only_mode:
             sequence_info = {
-                'SOPInstanceUID': getattr(row.DICOMDataset, 'SOPInstanceUID', 'None') or 'None',
+                'SOPInstanceUID': getattr(row, 'AnonSOPInstanceUID', '') or 'None',
                 'GrayscaleConversion': False
             }
 

--- a/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
@@ -172,10 +172,14 @@ class TestDicomFileManager:
         """Create a single-frame grayscale image array for testing (frames, height, width, channels)"""
         return np.random.randint(0, 255, (1, 10, 15, 1), dtype=np.uint8)
 
+    SOURCE_FOR_UID = "1.2.840.113619.2.1.1234"
+    ANON_FOR_UID = "2.25.123456789012345678901234567890"
+
     @pytest.fixture
     def manager_with_data(self, manager, temp_dir):
         """Create a manager with sample DICOM dataframe"""
         ds = self.create_test_dicom_file()
+        ds.FrameOfReferenceUID = self.SOURCE_FOR_UID
         filename = manager._generate_filename_from_dicom(ds)
         filepath = self.save_dicom_file(ds, temp_dir, filename)
 
@@ -190,6 +194,8 @@ class TestDicomFileManager:
             'SeriesUID': self.SERIES_UID,
             'SeriesDate': self.CONTENT_DATE,
             'InstanceUID': self.SOP_INSTANCE_UID,
+            'FrameOfReferenceUID': self.SOURCE_FOR_UID,
+            'AnonFrameOfReferenceUID': self.ANON_FOR_UID,
             'PhysicalDeltaX': self.PHYSICAL_DELTA_X,
             'PhysicalDeltaY': self.PHYSICAL_DELTA_Y,
             'ContentDate': self.CONTENT_DATE,
@@ -200,6 +206,9 @@ class TestDicomFileManager:
         }]
 
         manager._create_dataframe(dicom_data)
+        # Seed the in-memory map so direct _copy_and_generate_uids calls hit
+        # either the dataframe-column path or the _for_map fallback.
+        manager._for_map[(self.STUDY_UID, self.SOURCE_FOR_UID)] = self.ANON_FOR_UID
         manager.current_index = 0
         return manager
 
@@ -279,7 +288,7 @@ class TestDicomFileManager:
         filename, _, _ = manager.generate_filename_from_dicom_dataset(result['DICOMDataset'])
 
         assert result is not None
-        assert len(result) == 17
+        assert len(result) == 18
         assert result['InputPath'] == sample_dicom_filepath
         assert filename in result['OutputPath']
         assert result['AnonFilename'] == filename
@@ -1070,11 +1079,17 @@ class TestDicomFileManager:
         self, manager_with_data, temp_dir
     ):
         """Leakage guard: source FrameOfReferenceUID never appears in the output,
-        neither verbatim nor as its remap_uid hash. Hashed leakage would still let
-        recipients cluster de-id'd studies that shared a coordinate system."""
+        neither verbatim nor as its remap_uid hash. Under the run-local policy
+        the output FOR is a freshly minted 2.25 UID with no derivation from the
+        source value, so both inequality checks must hold."""
         ds = pydicom.Dataset()
         source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
         source_ds.FrameOfReferenceUID = "1.2.840.113619.2.1.99"
+        # _for_map has the test fixture's source FOR; this test uses a different
+        # one, so _copy_and_generate_uids must mint or look up by the new key.
+        manager_with_data._for_map[
+            (str(source_ds.StudyInstanceUID), "1.2.840.113619.2.1.99")
+        ] = "2.25.999999999999999999999999999"
         output_path = os.path.join(temp_dir, "test.dcm")
 
         manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
@@ -1082,52 +1097,13 @@ class TestDicomFileManager:
         assert ds.FrameOfReferenceUID != "1.2.840.113619.2.1.99"
         assert ds.FrameOfReferenceUID != remap_uid("1.2.840.113619.2.1.99")
 
-    def test_copy_and_generate_uids_frame_of_reference_derived_from_remapped_series_uid(
-        self, manager_with_data, temp_dir
-    ):
-        """FrameOfReferenceUID is regenerated from the already-remapped SeriesInstanceUID.
-
-        The source FOR UID is never read; the new FOR UID is remap_uid(ds.SeriesInstanceUID),
-        keeping all instances in the same de-id'd series sharing one coordinate UID.
-        """
-        ds = pydicom.Dataset()
-        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
-        source_ds.FrameOfReferenceUID = "1.2.840.113619.2.1.99"
-        output_path = os.path.join(temp_dir, "test.dcm")
-
-        manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
-
-        assert ds.FrameOfReferenceUID == remap_uid(str(ds.SeriesInstanceUID))
-        assert ds.FrameOfReferenceUID.startswith("2.25.")
-
-    def test_copy_and_generate_uids_frame_of_reference_independent_of_source_for_uid(
-        self, manager_with_data, temp_dir
-    ):
-        """Two different source FOR UIDs on the same series produce identical output FOR UIDs.
-
-        Proves the new FOR UID depends only on the remapped series UID and not at all
-        on source.FrameOfReferenceUID — the privacy guarantee.
-        """
-        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
-        output_path = os.path.join(temp_dir, "test.dcm")
-
-        ds_a = pydicom.Dataset()
-        source_ds.FrameOfReferenceUID = "1.2.840.113619.2.1.99"
-        manager_with_data._copy_and_generate_uids(ds_a, source_ds, output_path)
-
-        ds_b = pydicom.Dataset()
-        source_ds.FrameOfReferenceUID = "1.2.276.0.7230010.3.1.4.99999"
-        manager_with_data._copy_and_generate_uids(ds_b, source_ds, output_path)
-
-        assert ds_a.FrameOfReferenceUID == ds_b.FrameOfReferenceUID
-
     def test_copy_and_generate_uids_frame_of_reference_set_even_when_source_lacks_it(
         self, manager_with_data, temp_dir
     ):
         """FrameOfReferenceUID is Type 1/1C required for US IODs.
 
-        Even when source lacks one, the output must have one — derived from the
-        remapped SeriesInstanceUID so it still lives in the 2.25 arc.
+        Even when source lacks one, the output must have one — and it must live
+        in the 2.25 arc. The fallback minting path takes over in this branch.
         """
         ds = pydicom.Dataset()
         source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
@@ -1141,38 +1117,464 @@ class TestDicomFileManager:
         assert ds.FrameOfReferenceUID
         assert ds.FrameOfReferenceUID.startswith("2.25.")
 
-    def test_copy_and_generate_uids_frame_of_reference_shared_within_series(
+    # ----------------------------------------------------------------------
+    # New integration tests for the run-local per-study FOR UID policy.
+    # ----------------------------------------------------------------------
+
+    def _make_source_dicom(self, temp_dir, subdir, *, sop_instance_uid,
+                           series_instance_uid, study_instance_uid,
+                           frame_of_reference_uid=None, patient_id=None):
+        """Build and save a small DICOM with controllable UIDs for FOR tests."""
+        kwargs = {
+            'SOPInstanceUID': sop_instance_uid,
+            'SeriesInstanceUID': series_instance_uid,
+            'StudyInstanceUID': study_instance_uid,
+        }
+        if patient_id is not None:
+            kwargs['PatientID'] = patient_id
+        ds = self.create_test_dicom_file(**kwargs)
+        if frame_of_reference_uid is not None:
+            ds.FrameOfReferenceUID = frame_of_reference_uid
+        elif hasattr(ds, 'FrameOfReferenceUID'):
+            delattr(ds, 'FrameOfReferenceUID')
+        nested = os.path.join(temp_dir, subdir)
+        os.makedirs(nested, exist_ok=True)
+        # Use a deterministic distinct filename per instance so files don't clobber.
+        filename = f"{sop_instance_uid.replace('.', '_')}.dcm"
+        return self.save_dicom_file(ds, nested, filename)
+
+    def test_anon_for_uid_shared_across_series_with_same_source_for_in_same_study(
+        self, manager, temp_dir
+    ):
+        """Two series in one study sharing source FOR → shared AnonFrameOfReferenceUID."""
+        study_uid = "1.2.840.113619.2.55.STUDY.A"
+        shared_for = "1.2.840.113619.2.1.FOR1"
+        self._make_source_dicom(
+            temp_dir, "studyA/seriesA",
+            sop_instance_uid="1.2.A.1", series_instance_uid="1.2.A.SER1",
+            study_instance_uid=study_uid, frame_of_reference_uid=shared_for,
+        )
+        self._make_source_dicom(
+            temp_dir, "studyA/seriesB",
+            sop_instance_uid="1.2.A.2", series_instance_uid="1.2.A.SER2",
+            study_instance_uid=study_uid, frame_of_reference_uid=shared_for,
+        )
+
+        manager.scan_directory(temp_dir)
+
+        rows = manager.dicom_df[manager.dicom_df['StudyUID'] == study_uid]
+        assert len(rows) == 2
+        anon_values = rows['AnonFrameOfReferenceUID'].unique()
+        assert len(anon_values) == 1
+        assert anon_values[0].startswith("2.25.")
+
+    def test_anon_for_uid_differs_for_different_source_for_in_same_study(
+        self, manager, temp_dir
+    ):
+        """Same study, different source FORs → distinct AnonFrameOfReferenceUIDs."""
+        study_uid = "1.2.840.113619.2.55.STUDY.A"
+        self._make_source_dicom(
+            temp_dir, "studyA/seriesA",
+            sop_instance_uid="1.2.A.1", series_instance_uid="1.2.A.SER1",
+            study_instance_uid=study_uid, frame_of_reference_uid="1.2.FOR.X",
+        )
+        self._make_source_dicom(
+            temp_dir, "studyA/seriesC",
+            sop_instance_uid="1.2.A.3", series_instance_uid="1.2.A.SER3",
+            study_instance_uid=study_uid, frame_of_reference_uid="1.2.FOR.Y",
+        )
+
+        manager.scan_directory(temp_dir)
+
+        rows = manager.dicom_df[manager.dicom_df['StudyUID'] == study_uid]
+        anon_values = list(rows['AnonFrameOfReferenceUID'])
+        assert len(anon_values) == 2
+        assert anon_values[0] != anon_values[1]
+
+    def test_anon_for_uid_differs_across_studies_for_same_source_for(
+        self, manager, temp_dir
+    ):
+        """Coincidentally-shared source FOR across two studies → distinct anon FORs."""
+        shared_for = "1.2.840.113619.2.1.SHARED"
+        self._make_source_dicom(
+            temp_dir, "study1/seriesA",
+            sop_instance_uid="1.2.S1.1", series_instance_uid="1.2.S1.SER1",
+            study_instance_uid="1.2.STUDY.ONE", frame_of_reference_uid=shared_for,
+            patient_id="P1",
+        )
+        self._make_source_dicom(
+            temp_dir, "study2/seriesD",
+            sop_instance_uid="1.2.S2.1", series_instance_uid="1.2.S2.SER1",
+            study_instance_uid="1.2.STUDY.TWO", frame_of_reference_uid=shared_for,
+            patient_id="P2",
+        )
+
+        manager.scan_directory(temp_dir)
+
+        anon_s1 = manager.dicom_df[
+            manager.dicom_df['StudyUID'] == "1.2.STUDY.ONE"
+        ]['AnonFrameOfReferenceUID'].iloc[0]
+        anon_s2 = manager.dicom_df[
+            manager.dicom_df['StudyUID'] == "1.2.STUDY.TWO"
+        ]['AnonFrameOfReferenceUID'].iloc[0]
+        assert anon_s1 != anon_s2
+
+    def test_anon_for_uid_cardinality_matches_unique_source_for_per_study(
+        self, manager, temp_dir
+    ):
+        """3 unique source FORs across 5 series in one study → exactly 3 unique anon FORs."""
+        study_uid = "1.2.STUDY.MULTI"
+        spec = [
+            ("ser1", "1.2.FOR.A"),
+            ("ser2", "1.2.FOR.A"),
+            ("ser3", "1.2.FOR.B"),
+            ("ser4", "1.2.FOR.C"),
+            ("ser5", "1.2.FOR.B"),
+        ]
+        for i, (ser_label, for_uid) in enumerate(spec):
+            self._make_source_dicom(
+                temp_dir, f"study/{ser_label}",
+                sop_instance_uid=f"1.2.INST.{i}",
+                series_instance_uid=f"1.2.SER.{i}",
+                study_instance_uid=study_uid,
+                frame_of_reference_uid=for_uid,
+            )
+
+        manager.scan_directory(temp_dir)
+
+        nunique = manager.dicom_df.groupby('StudyUID')[
+            'AnonFrameOfReferenceUID'
+        ].nunique()
+        assert nunique[study_uid] == 3
+
+    def test_anon_for_uid_shared_across_instances_in_same_series(
+        self, manager, temp_dir
+    ):
+        """Two instances in one source series → shared AnonFrameOfReferenceUID."""
+        study_uid = "1.2.STUDY.ABC"
+        series_uid = "1.2.SER.SAME"
+        for_uid = "1.2.FOR.SAME"
+        self._make_source_dicom(
+            temp_dir, "study/ser1",
+            sop_instance_uid="1.2.INST.1",
+            series_instance_uid=series_uid,
+            study_instance_uid=study_uid,
+            frame_of_reference_uid=for_uid,
+        )
+        self._make_source_dicom(
+            temp_dir, "study/ser1",
+            sop_instance_uid="1.2.INST.2",
+            series_instance_uid=series_uid,
+            study_instance_uid=study_uid,
+            frame_of_reference_uid=for_uid,
+        )
+
+        manager.scan_directory(temp_dir)
+
+        rows = manager.dicom_df[manager.dicom_df['SeriesUID'] == series_uid]
+        assert len(rows) == 2
+        assert rows.iloc[0]['AnonFrameOfReferenceUID'] == rows.iloc[1]['AnonFrameOfReferenceUID']
+
+    def test_anon_for_uid_emitted_when_source_lacks_for_and_does_not_link_coordinateless_series(
+        self, manager, temp_dir
+    ):
+        """Two series in one study with no source FOR → both get UIDs but they differ.
+
+        Type 1/1C compliance: every output instance has a non-empty 2.25 UID.
+        Also: a missing source FOR must NOT be silently coalesced into a shared
+        anon UID across two coordinate-less series — that would be a false link.
+        """
+        study_uid = "1.2.STUDY.NO_FOR"
+        self._make_source_dicom(
+            temp_dir, "study/ser1",
+            sop_instance_uid="1.2.INST.X",
+            series_instance_uid="1.2.SER.X",
+            study_instance_uid=study_uid,
+            frame_of_reference_uid=None,
+        )
+        self._make_source_dicom(
+            temp_dir, "study/ser2",
+            sop_instance_uid="1.2.INST.Y",
+            series_instance_uid="1.2.SER.Y",
+            study_instance_uid=study_uid,
+            frame_of_reference_uid=None,
+        )
+
+        manager.scan_directory(temp_dir)
+
+        rows = manager.dicom_df[manager.dicom_df['StudyUID'] == study_uid]
+        anon_values = list(rows['AnonFrameOfReferenceUID'])
+        assert len(anon_values) == 2
+        assert all(v and v.startswith("2.25.") for v in anon_values)
+        assert anon_values[0] != anon_values[1]
+
+    def test_anon_for_uid_does_not_leak_source_value(self, manager, temp_dir):
+        """Integration leakage guard: output FOR ≠ source verbatim AND ≠ remap_uid(source)."""
+        leak_for = "1.2.840.113619.2.1.99"
+        self._make_source_dicom(
+            temp_dir, "study/ser1",
+            sop_instance_uid="1.2.INST.LEAK",
+            series_instance_uid="1.2.SER.LEAK",
+            study_instance_uid="1.2.STUDY.LEAK",
+            frame_of_reference_uid=leak_for,
+        )
+
+        manager.scan_directory(temp_dir)
+
+        anon_for = manager.dicom_df.iloc[0]['AnonFrameOfReferenceUID']
+        assert anon_for != leak_for
+        assert anon_for != remap_uid(leak_for)
+        assert anon_for.startswith("2.25.")
+
+    def test_anon_for_uid_is_run_local_not_deterministic(self, temp_dir):
+        """Two separate DicomFileManager runs over identical input → different anon FORs."""
+        self._make_source_dicom(
+            temp_dir, "study/ser1",
+            sop_instance_uid="1.2.INST.RL",
+            series_instance_uid="1.2.SER.RL",
+            study_instance_uid="1.2.STUDY.RL",
+            frame_of_reference_uid="1.2.FOR.RL",
+        )
+
+        m1 = DicomFileManager()
+        m1.scan_directory(temp_dir)
+        anon_first = m1.dicom_df.iloc[0]['AnonFrameOfReferenceUID']
+
+        m2 = DicomFileManager()
+        m2.scan_directory(temp_dir)
+        anon_second = m2.dicom_df.iloc[0]['AnonFrameOfReferenceUID']
+
+        assert anon_first != anon_second
+        assert anon_first.startswith("2.25.")
+        assert anon_second.startswith("2.25.")
+
+    def test_anon_for_uid_resume_reuses_prior_keys_csv_mapping(self, temp_dir):
+        """Resume: scan with seed_keys_csv from a prior run → prior anon FOR is reused."""
+        # First run.
+        self._make_source_dicom(
+            temp_dir, "study/ser1",
+            sop_instance_uid="1.2.INST.RESUME",
+            series_instance_uid="1.2.SER.RESUME",
+            study_instance_uid="1.2.STUDY.RESUME",
+            frame_of_reference_uid="1.2.FOR.RESUME",
+        )
+        m1 = DicomFileManager()
+        m1.scan_directory(temp_dir)
+        prior_keys_csv = os.path.join(temp_dir, "keys.csv")
+        m1.build_csv_dataframe(temp_dir).to_csv(prior_keys_csv, index=False)
+        prior_anon = m1.dicom_df.iloc[0]['AnonFrameOfReferenceUID']
+
+        # Second run with the seed.
+        m2 = DicomFileManager()
+        m2.scan_directory(temp_dir, seed_keys_csv=prior_keys_csv)
+
+        # Filter out the rescanned keys.csv itself (only .dcm rows match).
+        new_anon = m2.dicom_df[
+            m2.dicom_df['StudyUID'] == "1.2.STUDY.RESUME"
+        ]['AnonFrameOfReferenceUID'].iloc[0]
+        assert new_anon == prior_anon
+
+    def test_anon_for_uid_resume_mints_new_for_unseen_pairs(self, temp_dir):
+        """Resume seeds Study1; scanning Study1+Study2 → Study1 reuses, Study2 fresh."""
+        study1_subdir = os.path.join(temp_dir, "input1")
+        os.makedirs(study1_subdir)
+        self._make_source_dicom(
+            study1_subdir, "studyA",
+            sop_instance_uid="1.2.S1.INST",
+            series_instance_uid="1.2.S1.SER",
+            study_instance_uid="1.2.STUDY.SEEDED",
+            frame_of_reference_uid="1.2.FOR.SEEDED",
+        )
+        m1 = DicomFileManager()
+        m1.scan_directory(study1_subdir)
+        prior_keys_csv = os.path.join(temp_dir, "keys.csv")
+        m1.build_csv_dataframe(study1_subdir).to_csv(prior_keys_csv, index=False)
+        seeded_anon = m1.dicom_df.iloc[0]['AnonFrameOfReferenceUID']
+
+        # Second run scans a directory containing BOTH studies.
+        combined_subdir = os.path.join(temp_dir, "input2")
+        os.makedirs(combined_subdir)
+        # Recreate the seeded study so its files exist in this new input root.
+        self._make_source_dicom(
+            combined_subdir, "studyA",
+            sop_instance_uid="1.2.S1.INST",
+            series_instance_uid="1.2.S1.SER",
+            study_instance_uid="1.2.STUDY.SEEDED",
+            frame_of_reference_uid="1.2.FOR.SEEDED",
+        )
+        self._make_source_dicom(
+            combined_subdir, "studyB",
+            sop_instance_uid="1.2.S2.INST",
+            series_instance_uid="1.2.S2.SER",
+            study_instance_uid="1.2.STUDY.UNSEEN",
+            frame_of_reference_uid="1.2.FOR.UNSEEN",
+            patient_id="P2",
+        )
+
+        m2 = DicomFileManager()
+        m2.scan_directory(combined_subdir, seed_keys_csv=prior_keys_csv)
+
+        seeded_row_anon = m2.dicom_df[
+            m2.dicom_df['StudyUID'] == "1.2.STUDY.SEEDED"
+        ]['AnonFrameOfReferenceUID'].iloc[0]
+        unseen_row_anon = m2.dicom_df[
+            m2.dicom_df['StudyUID'] == "1.2.STUDY.UNSEEN"
+        ]['AnonFrameOfReferenceUID'].iloc[0]
+
+        assert seeded_row_anon == seeded_anon
+        assert unseen_row_anon != seeded_anon
+        assert unseen_row_anon.startswith("2.25.")
+
+    def test_anon_for_uid_resume_degrades_gracefully_for_old_keys_csv(self, temp_dir):
+        """A keys.csv missing FOR columns → no exception; all rows minted fresh."""
+        self._make_source_dicom(
+            temp_dir, "study/ser1",
+            sop_instance_uid="1.2.INST.OLDCSV",
+            series_instance_uid="1.2.SER.OLDCSV",
+            study_instance_uid="1.2.STUDY.OLDCSV",
+            frame_of_reference_uid="1.2.FOR.OLDCSV",
+        )
+        old_csv = os.path.join(temp_dir, "old_keys.csv")
+        # Synthesize an older keys.csv without the new columns.
+        pd.DataFrame([{
+            'InputPath': 'x.dcm',
+            'OutputPath': 'x.dcm',
+            'StudyUID': '1.2.STUDY.OLDCSV',
+            'SeriesUID': '1.2.SER.OLDCSV',
+            'AnonStudyUID': '2.25.111',
+        }]).to_csv(old_csv, index=False)
+
+        m = DicomFileManager()
+        m.scan_directory(temp_dir, seed_keys_csv=old_csv)
+
+        rows = m.dicom_df[m.dicom_df['StudyUID'] == "1.2.STUDY.OLDCSV"]
+        assert len(rows) == 1
+        anon = rows.iloc[0]['AnonFrameOfReferenceUID']
+        assert anon.startswith("2.25.")
+        # No partial seeding from the old csv was applied for FOR.
+        assert ("1.2.STUDY.OLDCSV", "1.2.FOR.OLDCSV") in m._for_map
+
+    def test_anon_for_uid_columns_in_keys_csv(self, manager, temp_dir):
+        """Both new columns persist into the keys.csv-ready dataframe."""
+        self._make_source_dicom(
+            temp_dir, "study/ser1",
+            sop_instance_uid="1.2.INST.CSV",
+            series_instance_uid="1.2.SER.CSV",
+            study_instance_uid="1.2.STUDY.CSV",
+            frame_of_reference_uid="1.2.FOR.CSV",
+        )
+
+        manager.scan_directory(temp_dir)
+        csv_df = manager.build_csv_dataframe(temp_dir)
+
+        assert csv_df is not None
+        assert 'FrameOfReferenceUID' in csv_df.columns
+        assert 'AnonFrameOfReferenceUID' in csv_df.columns
+        assert 'DICOMDataset' not in csv_df.columns
+
+    # ----------------------------------------------------------------------
+    # Unit-level _copy_and_generate_uids three-tier read path tests.
+    # ----------------------------------------------------------------------
+
+    def test_copy_and_generate_uids_uses_anon_for_from_dataframe(
         self, manager_with_data, temp_dir
     ):
-        """Two instances in the same source series get the same output FOR UID.
-
-        Uses DIFFERENT source.FrameOfReferenceUID values across the two datasets
-        so the current (pre-fix) behavior — which derives from source FOR UID —
-        would produce DIFFERENT outputs and fail this test, surfacing the bug.
-        """
+        """Primary read path: AnonFrameOfReferenceUID column wins."""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
         output_path = os.path.join(temp_dir, "test.dcm")
-        shared_series_uid = "1.2.840.113619.2.55.3.604688432.781.1591781234.500"
+        # Sentinel that does NOT match the fixture-seeded _for_map value,
+        # so we know the column is what was read.
+        manager_with_data.dicom_df.at[0, 'AnonFrameOfReferenceUID'] = "2.25.SENTINEL"
 
-        source_a = pydicom.Dataset()
-        source_a.SOPClassUID = "1.2.840.10008.5.1.4.1.1.6.1"
-        source_a.SOPInstanceUID = "1.2.840.113619.2.55.3.604688432.781.1591781234.501"
-        source_a.SeriesInstanceUID = shared_series_uid
-        source_a.StudyInstanceUID = "1.2.840.113619.2.55.3.604688432.781.1591781234.502"
-        source_a.FrameOfReferenceUID = "1.2.840.113619.2.1.111"
+        manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
 
-        source_b = pydicom.Dataset()
-        source_b.SOPClassUID = "1.2.840.10008.5.1.4.1.1.6.1"
-        source_b.SOPInstanceUID = "1.2.840.113619.2.55.3.604688432.781.1591781234.503"
-        source_b.SeriesInstanceUID = shared_series_uid
-        source_b.StudyInstanceUID = "1.2.840.113619.2.55.3.604688432.781.1591781234.502"
-        source_b.FrameOfReferenceUID = "1.2.840.113619.2.1.222"
+        assert ds.FrameOfReferenceUID == "2.25.SENTINEL"
 
-        ds_a = pydicom.Dataset()
-        ds_b = pydicom.Dataset()
-        manager_with_data._copy_and_generate_uids(ds_a, source_a, output_path)
-        manager_with_data._copy_and_generate_uids(ds_b, source_b, output_path)
+    def test_copy_and_generate_uids_falls_back_to_for_map_when_df_column_missing(
+        self, manager_with_data, temp_dir
+    ):
+        """Fallback path: when the dataframe column is absent, _for_map is consulted."""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        output_path = os.path.join(temp_dir, "test.dcm")
+        # Drop the column so the primary path can't fire.
+        manager_with_data.dicom_df = manager_with_data.dicom_df.drop(
+            columns=['AnonFrameOfReferenceUID']
+        )
+        manager_with_data._for_map[
+            (str(source_ds.StudyInstanceUID), str(source_ds.FrameOfReferenceUID))
+        ] = "2.25.MAPSENTINEL"
 
-        assert ds_a.FrameOfReferenceUID == ds_b.FrameOfReferenceUID
+        manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
+
+        assert ds.FrameOfReferenceUID == "2.25.MAPSENTINEL"
+
+    def test_copy_and_generate_uids_last_resort_mints_for_when_no_mapping_available(
+        self, manager_with_data, temp_dir, caplog
+    ):
+        """Last-resort fallback: no dataframe column AND no _for_map entry → mint + log error."""
+        ds = pydicom.Dataset()
+        # Construct a source_ds whose (StudyUID, FOR) is not in the manager's
+        # seeded map and that has a brand-new FOR not in the column.
+        source_ds = pydicom.Dataset()
+        source_ds.SOPClassUID = "1.2.840.10008.5.1.4.1.1.6.1"
+        source_ds.SOPInstanceUID = "1.2.NOMAP.INST"
+        source_ds.SeriesInstanceUID = "1.2.NOMAP.SER"
+        source_ds.StudyInstanceUID = "1.2.NOMAP.STUDY"
+        source_ds.FrameOfReferenceUID = "1.2.NOMAP.FOR"
+        # Drop the column AND clear the map.
+        manager_with_data.dicom_df = manager_with_data.dicom_df.drop(
+            columns=['AnonFrameOfReferenceUID']
+        )
+        manager_with_data._for_map.clear()
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        with caplog.at_level(logging.ERROR):
+            manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
+
+        assert ds.FrameOfReferenceUID
+        assert ds.FrameOfReferenceUID.startswith("2.25.")
+        assert any("AnonFrameOfReferenceUID" in r.message for r in caplog.records)
+
+    # ----------------------------------------------------------------------
+    # End-to-end save → read round-trip.
+    # ----------------------------------------------------------------------
+
+    def test_save_anonymized_dicom_emits_shared_for_uid_for_co_located_series(
+        self, manager, temp_dir, sample_image_array_single_frame
+    ):
+        """Two series sharing source FOR in one study → saved files share output FOR."""
+        study_uid = "1.2.STUDY.E2E"
+        shared_for = "1.2.FOR.E2E"
+        self._make_source_dicom(
+            temp_dir, "study/serA",
+            sop_instance_uid="1.2.INST.E2E.A",
+            series_instance_uid="1.2.SER.E2E.A",
+            study_instance_uid=study_uid,
+            frame_of_reference_uid=shared_for,
+        )
+        self._make_source_dicom(
+            temp_dir, "study/serB",
+            sop_instance_uid="1.2.INST.E2E.B",
+            series_instance_uid="1.2.SER.E2E.B",
+            study_instance_uid=study_uid,
+            frame_of_reference_uid=shared_for,
+        )
+
+        manager.scan_directory(temp_dir)
+
+        outputs = []
+        for idx in range(len(manager.dicom_df)):
+            manager.current_index = idx
+            out_path = os.path.join(temp_dir, "out", f"out_{idx}.dcm")
+            manager.save_anonymized_dicom(sample_image_array_single_frame, out_path)
+            outputs.append(out_path)
+
+        a = pydicom.dcmread(outputs[0])
+        b = pydicom.dcmread(outputs[1])
+        assert a.FrameOfReferenceUID == b.FrameOfReferenceUID
+        assert a.FrameOfReferenceUID.startswith("2.25.")
 
     def test_apply_anonymization_computes_age_in_years_from_birthdate(self, manager_with_data):
         """When source has BirthDate+StudyDate but no PatientAge, age is computed in years."""

--- a/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
@@ -1066,6 +1066,214 @@ class TestDicomFileManager:
 
         assert len(caplog.records) == 0
 
+    def test_copy_and_generate_uids_remaps_frame_of_reference_uid(self, manager_with_data, temp_dir):
+        """FrameOfReferenceUID present in source is remapped via remap_uid (PS3.15 E.1.1 action U)."""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.FrameOfReferenceUID = "1.2.840.113619.2.1.99"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
+
+        assert ds.FrameOfReferenceUID == remap_uid("1.2.840.113619.2.1.99")
+        assert ds.FrameOfReferenceUID.startswith("2.25.")
+
+    def test_copy_and_generate_uids_frame_of_reference_remap_deterministic(self, manager_with_data, temp_dir):
+        """Same source FrameOfReferenceUID yields the same remapped output (cross-dataset linkage)."""
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.FrameOfReferenceUID = "1.2.840.113619.2.1.99"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        ds_a = pydicom.Dataset()
+        ds_b = pydicom.Dataset()
+        manager_with_data._copy_and_generate_uids(ds_a, source_ds, output_path)
+        manager_with_data._copy_and_generate_uids(ds_b, source_ds, output_path)
+
+        assert ds_a.FrameOfReferenceUID == ds_b.FrameOfReferenceUID
+
+    def test_copy_and_generate_uids_omits_frame_of_reference_when_source_lacks_it(
+        self, manager_with_data, temp_dir
+    ):
+        """When the source has no FrameOfReferenceUID, the output must not invent one."""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        if hasattr(source_ds, 'FrameOfReferenceUID'):
+            delattr(source_ds, 'FrameOfReferenceUID')
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
+
+        assert not hasattr(ds, 'FrameOfReferenceUID')
+
+    def test_copy_and_generate_uids_does_not_copy_frame_of_reference_verbatim(
+        self, manager_with_data, temp_dir
+    ):
+        """Leakage guard: source FrameOfReferenceUID never appears verbatim in the de-id output."""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.FrameOfReferenceUID = "1.2.840.113619.2.1.99"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
+
+        assert ds.FrameOfReferenceUID != "1.2.840.113619.2.1.99"
+
+    def test_apply_anonymization_computes_age_in_years_from_birthdate(self, manager_with_data):
+        """When source has BirthDate+StudyDate but no PatientAge, age is computed in years."""
+        ds = pydicom.Dataset()
+        source_ds = pydicom.Dataset()
+        source_ds.PatientID = "TEST123"
+        source_ds.PatientBirthDate = "19800101"
+        source_ds.StudyDate = "20200101"
+
+        manager_with_data._apply_anonymization(ds, source_ds)
+
+        assert ds.PatientAge == "040Y"
+
+    def test_apply_anonymization_computes_age_in_months_for_infant(self, manager_with_data):
+        """Infant age (>=31 days, <365) is computed in months using 30.4375 days/month."""
+        ds = pydicom.Dataset()
+        source_ds = pydicom.Dataset()
+        source_ds.PatientID = "TEST123"
+        source_ds.PatientBirthDate = "20191215"
+        source_ds.StudyDate = "20200615"
+
+        manager_with_data._apply_anonymization(ds, source_ds)
+
+        assert ds.PatientAge == "006M"
+
+    def test_apply_anonymization_computes_age_in_days_for_newborn(self, manager_with_data):
+        """Newborn age (<31 days) is computed in days, zero-padded to three digits."""
+        ds = pydicom.Dataset()
+        source_ds = pydicom.Dataset()
+        source_ds.PatientID = "TEST123"
+        source_ds.PatientBirthDate = "20200115"
+        source_ds.StudyDate = "20200125"
+
+        manager_with_data._apply_anonymization(ds, source_ds)
+
+        assert ds.PatientAge == "010D"
+
+    def test_apply_anonymization_computed_age_capped_at_90y(self, manager_with_data):
+        """Computed age >= 90 years is capped at '090Y' per HIPAA Safe Harbor."""
+        ds = pydicom.Dataset()
+        source_ds = pydicom.Dataset()
+        source_ds.PatientID = "TEST123"
+        source_ds.PatientBirthDate = "19200101"
+        source_ds.StudyDate = "20200101"
+
+        manager_with_data._apply_anonymization(ds, source_ds)
+
+        assert ds.PatientAge == "090Y"
+
+    def test_apply_anonymization_preserves_existing_patient_age_does_not_recompute(
+        self, manager_with_data
+    ):
+        """Source PatientAge wins over a (different) BirthDate-derived value — no overwrite."""
+        ds = pydicom.Dataset()
+        ds.PatientAge = "045Y"
+        source_ds = pydicom.Dataset()
+        source_ds.PatientID = "TEST123"
+        source_ds.PatientBirthDate = "19500101"
+        source_ds.StudyDate = "20200101"
+
+        manager_with_data._apply_anonymization(ds, source_ds)
+
+        assert ds.PatientAge == "045Y"
+
+    def test_apply_anonymization_missing_birthdate_no_age_set_logs_warning(
+        self, manager_with_data, caplog
+    ):
+        """With no PatientAge and no BirthDate, PatientAge is left absent and a warning is logged."""
+        ds = pydicom.Dataset()
+        source_ds = pydicom.Dataset()
+        source_ds.PatientID = "TEST123"
+        source_ds.StudyDate = "20200101"
+
+        with caplog.at_level(logging.WARNING):
+            manager_with_data._apply_anonymization(ds, source_ds)
+
+        assert not hasattr(ds, 'PatientAge')
+        assert any("PatientAge" in r.message for r in caplog.records)
+
+    def test_apply_anonymization_missing_studydate_no_age_set_logs_warning(
+        self, manager_with_data, caplog
+    ):
+        """With no PatientAge and no StudyDate, PatientAge is left absent and a warning is logged."""
+        ds = pydicom.Dataset()
+        source_ds = pydicom.Dataset()
+        source_ds.PatientID = "TEST123"
+        source_ds.PatientBirthDate = "19800101"
+
+        with caplog.at_level(logging.WARNING):
+            manager_with_data._apply_anonymization(ds, source_ds)
+
+        assert not hasattr(ds, 'PatientAge')
+        assert any("PatientAge" in r.message for r in caplog.records)
+
+    def test_apply_anonymization_birthdate_after_studydate_logs_warning(
+        self, manager_with_data, caplog
+    ):
+        """If BirthDate is after StudyDate (data error), no age is set and a warning is logged."""
+        ds = pydicom.Dataset()
+        source_ds = pydicom.Dataset()
+        source_ds.PatientID = "TEST123"
+        source_ds.PatientBirthDate = "20200101"
+        source_ds.StudyDate = "20190101"
+
+        with caplog.at_level(logging.WARNING):
+            manager_with_data._apply_anonymization(ds, source_ds)
+
+        assert not hasattr(ds, 'PatientAge')
+        assert any("PatientAge" in r.message or "BirthDate" in r.message
+                   for r in caplog.records)
+
+    def test_apply_anonymization_malformed_birthdate_logs_warning(
+        self, manager_with_data, caplog
+    ):
+        """A non-parseable BirthDate yields no PatientAge and logs a warning (not an error)."""
+        ds = pydicom.Dataset()
+        source_ds = pydicom.Dataset()
+        source_ds.PatientID = "TEST123"
+        source_ds.PatientBirthDate = "BADDATE"
+        source_ds.StudyDate = "20200101"
+
+        with caplog.at_level(logging.WARNING):
+            manager_with_data._apply_anonymization(ds, source_ds)
+
+        assert not hasattr(ds, 'PatientAge')
+        assert any("PatientAge" in r.message or "BirthDate" in r.message
+                   for r in caplog.records)
+
+    def test_apply_anonymization_empty_birthdate_no_age_set_no_error(
+        self, manager_with_data, caplog
+    ):
+        """Empty BirthDate is a valid 'no value' state — no age set, no ERROR-level log."""
+        ds = pydicom.Dataset()
+        source_ds = pydicom.Dataset()
+        source_ds.PatientID = "TEST123"
+        source_ds.PatientBirthDate = ""
+        source_ds.StudyDate = "20200101"
+
+        with caplog.at_level(logging.WARNING):
+            manager_with_data._apply_anonymization(ds, source_ds)
+
+        assert not hasattr(ds, 'PatientAge')
+        assert all(r.levelno < logging.ERROR for r in caplog.records)
+
+    def test_apply_anonymization_clears_birthdate_when_age_computed(self, manager_with_data):
+        """PatientBirthDate is still cleared to '' even when PatientAge is computed from it."""
+        ds = pydicom.Dataset()
+        source_ds = pydicom.Dataset()
+        source_ds.PatientID = "TEST123"
+        source_ds.PatientBirthDate = "19800101"
+        source_ds.StudyDate = "20200101"
+
+        manager_with_data._apply_anonymization(ds, source_ds)
+
+        assert ds.PatientBirthDate == ""
+        assert ds.PatientAge == "040Y"
+
     def test_copy_source_metadata_preserves_transducer_type(self, manager_with_data, temp_dir):
         """Test TransducerType present in source is preserved in de-id output"""
         ds = pydicom.Dataset()

--- a/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
@@ -1066,49 +1066,12 @@ class TestDicomFileManager:
 
         assert len(caplog.records) == 0
 
-    def test_copy_and_generate_uids_remaps_frame_of_reference_uid(self, manager_with_data, temp_dir):
-        """FrameOfReferenceUID present in source is remapped via remap_uid (PS3.15 E.1.1 action U)."""
-        ds = pydicom.Dataset()
-        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
-        source_ds.FrameOfReferenceUID = "1.2.840.113619.2.1.99"
-        output_path = os.path.join(temp_dir, "test.dcm")
-
-        manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
-
-        assert ds.FrameOfReferenceUID == remap_uid("1.2.840.113619.2.1.99")
-        assert ds.FrameOfReferenceUID.startswith("2.25.")
-
-    def test_copy_and_generate_uids_frame_of_reference_remap_deterministic(self, manager_with_data, temp_dir):
-        """Same source FrameOfReferenceUID yields the same remapped output (cross-dataset linkage)."""
-        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
-        source_ds.FrameOfReferenceUID = "1.2.840.113619.2.1.99"
-        output_path = os.path.join(temp_dir, "test.dcm")
-
-        ds_a = pydicom.Dataset()
-        ds_b = pydicom.Dataset()
-        manager_with_data._copy_and_generate_uids(ds_a, source_ds, output_path)
-        manager_with_data._copy_and_generate_uids(ds_b, source_ds, output_path)
-
-        assert ds_a.FrameOfReferenceUID == ds_b.FrameOfReferenceUID
-
-    def test_copy_and_generate_uids_omits_frame_of_reference_when_source_lacks_it(
-        self, manager_with_data, temp_dir
-    ):
-        """When the source has no FrameOfReferenceUID, the output must not invent one."""
-        ds = pydicom.Dataset()
-        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
-        if hasattr(source_ds, 'FrameOfReferenceUID'):
-            delattr(source_ds, 'FrameOfReferenceUID')
-        output_path = os.path.join(temp_dir, "test.dcm")
-
-        manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
-
-        assert not hasattr(ds, 'FrameOfReferenceUID')
-
     def test_copy_and_generate_uids_does_not_copy_frame_of_reference_verbatim(
         self, manager_with_data, temp_dir
     ):
-        """Leakage guard: source FrameOfReferenceUID never appears verbatim in the de-id output."""
+        """Leakage guard: source FrameOfReferenceUID never appears in the output,
+        neither verbatim nor as its remap_uid hash. Hashed leakage would still let
+        recipients cluster de-id'd studies that shared a coordinate system."""
         ds = pydicom.Dataset()
         source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
         source_ds.FrameOfReferenceUID = "1.2.840.113619.2.1.99"
@@ -1117,6 +1080,99 @@ class TestDicomFileManager:
         manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
 
         assert ds.FrameOfReferenceUID != "1.2.840.113619.2.1.99"
+        assert ds.FrameOfReferenceUID != remap_uid("1.2.840.113619.2.1.99")
+
+    def test_copy_and_generate_uids_frame_of_reference_derived_from_remapped_series_uid(
+        self, manager_with_data, temp_dir
+    ):
+        """FrameOfReferenceUID is regenerated from the already-remapped SeriesInstanceUID.
+
+        The source FOR UID is never read; the new FOR UID is remap_uid(ds.SeriesInstanceUID),
+        keeping all instances in the same de-id'd series sharing one coordinate UID.
+        """
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.FrameOfReferenceUID = "1.2.840.113619.2.1.99"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
+
+        assert ds.FrameOfReferenceUID == remap_uid(str(ds.SeriesInstanceUID))
+        assert ds.FrameOfReferenceUID.startswith("2.25.")
+
+    def test_copy_and_generate_uids_frame_of_reference_independent_of_source_for_uid(
+        self, manager_with_data, temp_dir
+    ):
+        """Two different source FOR UIDs on the same series produce identical output FOR UIDs.
+
+        Proves the new FOR UID depends only on the remapped series UID and not at all
+        on source.FrameOfReferenceUID — the privacy guarantee.
+        """
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        ds_a = pydicom.Dataset()
+        source_ds.FrameOfReferenceUID = "1.2.840.113619.2.1.99"
+        manager_with_data._copy_and_generate_uids(ds_a, source_ds, output_path)
+
+        ds_b = pydicom.Dataset()
+        source_ds.FrameOfReferenceUID = "1.2.276.0.7230010.3.1.4.99999"
+        manager_with_data._copy_and_generate_uids(ds_b, source_ds, output_path)
+
+        assert ds_a.FrameOfReferenceUID == ds_b.FrameOfReferenceUID
+
+    def test_copy_and_generate_uids_frame_of_reference_set_even_when_source_lacks_it(
+        self, manager_with_data, temp_dir
+    ):
+        """FrameOfReferenceUID is Type 1/1C required for US IODs.
+
+        Even when source lacks one, the output must have one — derived from the
+        remapped SeriesInstanceUID so it still lives in the 2.25 arc.
+        """
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        if hasattr(source_ds, 'FrameOfReferenceUID'):
+            delattr(source_ds, 'FrameOfReferenceUID')
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
+
+        assert hasattr(ds, 'FrameOfReferenceUID')
+        assert ds.FrameOfReferenceUID
+        assert ds.FrameOfReferenceUID.startswith("2.25.")
+
+    def test_copy_and_generate_uids_frame_of_reference_shared_within_series(
+        self, manager_with_data, temp_dir
+    ):
+        """Two instances in the same source series get the same output FOR UID.
+
+        Uses DIFFERENT source.FrameOfReferenceUID values across the two datasets
+        so the current (pre-fix) behavior — which derives from source FOR UID —
+        would produce DIFFERENT outputs and fail this test, surfacing the bug.
+        """
+        output_path = os.path.join(temp_dir, "test.dcm")
+        shared_series_uid = "1.2.840.113619.2.55.3.604688432.781.1591781234.500"
+
+        source_a = pydicom.Dataset()
+        source_a.SOPClassUID = "1.2.840.10008.5.1.4.1.1.6.1"
+        source_a.SOPInstanceUID = "1.2.840.113619.2.55.3.604688432.781.1591781234.501"
+        source_a.SeriesInstanceUID = shared_series_uid
+        source_a.StudyInstanceUID = "1.2.840.113619.2.55.3.604688432.781.1591781234.502"
+        source_a.FrameOfReferenceUID = "1.2.840.113619.2.1.111"
+
+        source_b = pydicom.Dataset()
+        source_b.SOPClassUID = "1.2.840.10008.5.1.4.1.1.6.1"
+        source_b.SOPInstanceUID = "1.2.840.113619.2.55.3.604688432.781.1591781234.503"
+        source_b.SeriesInstanceUID = shared_series_uid
+        source_b.StudyInstanceUID = "1.2.840.113619.2.55.3.604688432.781.1591781234.502"
+        source_b.FrameOfReferenceUID = "1.2.840.113619.2.1.222"
+
+        ds_a = pydicom.Dataset()
+        ds_b = pydicom.Dataset()
+        manager_with_data._copy_and_generate_uids(ds_a, source_a, output_path)
+        manager_with_data._copy_and_generate_uids(ds_b, source_b, output_path)
+
+        assert ds_a.FrameOfReferenceUID == ds_b.FrameOfReferenceUID
 
     def test_apply_anonymization_computes_age_in_years_from_birthdate(self, manager_with_data):
         """When source has BirthDate+StudyDate but no PatientAge, age is computed in years."""

--- a/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
@@ -13,6 +13,7 @@ import json
 
 # Import the module under test
 from ..dicom_file_manager import DicomFileManager
+from ..uid_remap import remap_uid
 
 class TestDicomFileManager:
     """Test suite for DicomFileManager class"""
@@ -278,7 +279,7 @@ class TestDicomFileManager:
         filename, _, _ = manager.generate_filename_from_dicom_dataset(result['DICOMDataset'])
 
         assert result is not None
-        assert len(result) == 14
+        assert len(result) == 17
         assert result['InputPath'] == sample_dicom_filepath
         assert filename in result['OutputPath']
         assert result['AnonFilename'] == filename
@@ -286,6 +287,9 @@ class TestDicomFileManager:
         assert result['StudyUID'] == self.STUDY_UID
         assert result['SeriesUID'] == self.SERIES_UID
         assert result['InstanceUID'] == self.SOP_INSTANCE_UID
+        assert result['AnonStudyUID'] == remap_uid(self.STUDY_UID)
+        assert result['AnonSeriesUID'] == remap_uid(self.SERIES_UID)
+        assert result['AnonSOPInstanceUID'] == remap_uid(self.SOP_INSTANCE_UID)
         assert result['ContentDate'] == self.CONTENT_DATE
         assert result['ContentTime'] == self.CONTENT_TIME
         assert result['Patch'] is False
@@ -784,33 +788,38 @@ class TestDicomFileManager:
         assert hasattr(ds, 'SeriesInstanceUID')
 
     def test_copy_and_generate_uids_with_source_uids(self, manager_with_data, temp_dir):
-        """Test _copy_and_generate_uids with existing UIDs in source"""
+        """Source instance UIDs are remapped via remap_uid; SOPClassUID stays verbatim."""
         ds = pydicom.Dataset()
         source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
         output_path = os.path.join(temp_dir, "test.dcm")
 
         manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
 
-        # Should copy existing UIDs
+        # SOPClassUID identifies the registered DICOM object type — NOT remapped.
         assert ds.SOPClassUID == source_ds.SOPClassUID
-        assert ds.SOPInstanceUID == source_ds.SOPInstanceUID
-        assert ds.StudyInstanceUID == source_ds.StudyInstanceUID
-        # SeriesInstanceUID should now be copied from source
-        assert ds.SeriesInstanceUID == source_ds.SeriesInstanceUID
+        # Study/Series/SOP Instance UIDs are deterministically remapped.
+        assert ds.SOPInstanceUID == remap_uid(str(source_ds.SOPInstanceUID))
+        assert ds.SeriesInstanceUID == remap_uid(str(source_ds.SeriesInstanceUID))
+        assert ds.StudyInstanceUID == remap_uid(str(source_ds.StudyInstanceUID))
+        # Outputs must live in the 2.25.* arc.
+        assert ds.SOPInstanceUID.startswith("2.25.")
+        assert ds.SeriesInstanceUID.startswith("2.25.")
+        assert ds.StudyInstanceUID.startswith("2.25.")
 
     def test_copy_and_generate_uids_missing_source_uids(self, manager_with_data, temp_dir):
-        """Test _copy_and_generate_uids with missing UIDs in source"""
+        """When source UIDs are missing, instance UIDs land in the 2.25 arc."""
         ds = pydicom.Dataset()
         source_ds = pydicom.Dataset()  # Empty dataset
         output_path = os.path.join(temp_dir, "test.dcm")
 
         manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
 
-        # Should generate new UIDs
+        # SOPClassUID falls back to pydicom-generated; not constrained to 2.25.
         assert hasattr(ds, 'SOPClassUID')
-        assert hasattr(ds, 'SOPInstanceUID')
-        assert hasattr(ds, 'StudyInstanceUID')
-        assert hasattr(ds, 'SeriesInstanceUID')
+        # Study/Series/SOP Instance UIDs are routed through remap_uid even on fallback.
+        assert ds.SOPInstanceUID.startswith("2.25.")
+        assert ds.StudyInstanceUID.startswith("2.25.")
+        assert ds.SeriesInstanceUID.startswith("2.25.")
 
     def test_apply_anonymization_with_new_patient_info(self, manager_with_data):
         """Test _apply_anonymization with new patient information"""
@@ -1119,8 +1128,8 @@ class TestDicomFileManager:
         assert hasattr(ds, 'TransducerData')
         assert ds.TransducerData == ""
 
-    def test_copy_source_metadata_preserves_transducer_data_serial(self, manager_with_data, temp_dir):
-        """TransducerData in de-id retains the raw source value, including the serial segment"""
+    def test_copy_source_metadata_strips_transducer_data_serial(self, manager_with_data, temp_dir):
+        """Comma-delimited TransducerData is trimmed to the leading model segment."""
         ds = pydicom.Dataset()
         source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
         source_ds.TransducerData = "SC6-1s,JK9U41102597"
@@ -1128,10 +1137,10 @@ class TestDicomFileManager:
 
         manager_with_data._copy_source_metadata(ds, source_ds, output_path)
 
-        assert ds.TransducerData == "SC6-1s,JK9U41102597"
+        assert ds.TransducerData == "SC6-1s"
 
-    def test_copy_source_metadata_preserves_transducer_data_backslash(self, manager_with_data, temp_dir):
-        """Backslash-delimited TransducerData is preserved element-wise in the de-id DICOM"""
+    def test_copy_source_metadata_strips_transducer_data_backslash(self, manager_with_data, temp_dir):
+        """Backslash-delimited TransducerData (VR LO MultiValue) collapses to the first segment string."""
         from pydicom.multival import MultiValue
         ds = pydicom.Dataset()
         source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
@@ -1140,10 +1149,10 @@ class TestDicomFileManager:
 
         manager_with_data._copy_source_metadata(ds, source_ds, output_path)
 
-        assert list(ds.TransducerData) == ["S4-1U", "UNUSED", "UNUSED"]
+        assert ds.TransducerData == "S4-1U"
 
     def test_copy_source_metadata_preserves_transducer_data_case(self, manager_with_data, temp_dir):
-        """TransducerData model segment in de-id preserves original case (unlike TransducerModel DataFrame column)"""
+        """A single-segment TransducerData (no delimiter) survives unchanged with original case."""
         ds = pydicom.Dataset()
         source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
         source_ds.TransducerData = "C1-5"
@@ -1152,6 +1161,85 @@ class TestDicomFileManager:
         manager_with_data._copy_source_metadata(ds, source_ds, output_path)
 
         assert ds.TransducerData == "C1-5"
+
+    def test_copy_source_metadata_strips_transducer_data_sp5_cb3c(self, manager_with_data, temp_dir):
+        """User example: 'SP5-1s,CB3C' -> 'SP5-1s'."""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.TransducerData = "SP5-1s,CB3C"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert ds.TransducerData == "SP5-1s"
+
+    def test_copy_source_metadata_strips_transducer_data_sc6_jk9(self, manager_with_data, temp_dir):
+        """User example: 'SC6-1s,JK9' -> 'SC6-1s'."""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.TransducerData = "SC6-1s,JK9"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert ds.TransducerData == "SC6-1s"
+
+    def test_copy_source_metadata_strips_transducer_data_only_delimiters(self, manager_with_data, temp_dir):
+        """Pathological all-delimiter input becomes empty."""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.TransducerData = "\\\\"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert ds.TransducerData == ""
+
+    def test_copy_source_metadata_strips_transducer_data_with_whitespace(self, manager_with_data, temp_dir):
+        """Internal whitespace around the leading segment is stripped."""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.TransducerData = " SC6-1s ,02597"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert ds.TransducerData == "SC6-1s"
+
+    def test_copy_source_metadata_preserves_manufacturer(self, manager_with_data, temp_dir):
+        """Manufacturer (0008,0070) round-trips verbatim — regression lock."""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.Manufacturer = "GE Healthcare"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert ds.Manufacturer == "GE Healthcare"
+
+    def test_copy_source_metadata_preserves_manufacturer_model_name(self, manager_with_data, temp_dir):
+        """ManufacturerModelName (0008,1090) round-trips verbatim — regression lock."""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.ManufacturerModelName = "Vivid E95"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert ds.ManufacturerModelName == "Vivid E95"
+
+    def test_copy_source_metadata_preserves_ge_vivid_pair(self, manager_with_data, temp_dir):
+        """Most common GE configuration: both vendor/model survive intact together."""
+        ds = pydicom.Dataset()
+        source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
+        source_ds.Manufacturer = "GE Healthcare"
+        source_ds.ManufacturerModelName = "Vivid E95"
+        output_path = os.path.join(temp_dir, "test.dcm")
+
+        manager_with_data._copy_source_metadata(ds, source_ds, output_path)
+
+        assert ds.Manufacturer == "GE Healthcare"
+        assert ds.ManufacturerModelName == "Vivid E95"
 
     def test_apply_anonymization_generates_uids_when_none_provided(self, manager_with_data):
         """Test that _apply_anonymization generates UIDs when no patient info provided"""
@@ -1368,9 +1456,8 @@ class TestDicomFileManager:
         assert len(result) == 3
         assert all(isinstance(item, str) for item in result)
 
-    # Test that SeriesInstanceUID is now passed through from source
-    def test_copy_and_generate_uids_passes_through_series_uid(self, manager_with_data, temp_dir):
-        """Test that SeriesInstanceUID is copied from source when present"""
+    def test_copy_and_generate_uids_remaps_series_uid(self, manager_with_data, temp_dir):
+        """SeriesInstanceUID is remapped via remap_uid when source provides one."""
         ds = pydicom.Dataset()
         source_ds = manager_with_data.dicom_df.iloc[0].DICOMDataset
         output_path = os.path.join(temp_dir, "test.dcm")
@@ -1379,18 +1466,18 @@ class TestDicomFileManager:
 
         manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
 
-        assert ds.SeriesInstanceUID == original_series_uid
+        assert ds.SeriesInstanceUID == remap_uid(str(original_series_uid))
+        assert ds.SeriesInstanceUID != original_series_uid
 
     def test_copy_and_generate_uids_generates_series_uid_when_missing(self, manager_with_data, temp_dir):
-        """Test that SeriesInstanceUID is freshly generated when source lacks it"""
+        """When SeriesInstanceUID is missing, the fallback still lands in the 2.25 arc."""
         ds = pydicom.Dataset()
         source_ds = pydicom.Dataset()  # empty — no SeriesInstanceUID
         output_path = os.path.join(temp_dir, "test.dcm")
 
         manager_with_data._copy_and_generate_uids(ds, source_ds, output_path)
 
-        assert hasattr(ds, 'SeriesInstanceUID')
-        assert ds.SeriesInstanceUID != ""
+        assert ds.SeriesInstanceUID.startswith("2.25.")
 
     @patch('pydicom.dataset.FileDataset.save_as')
     def test_create_and_save_dicom_file(self, mock_save_as, manager_with_data, temp_dir):
@@ -1700,6 +1787,9 @@ class TestBuildCsvDataframe:
             'StudyUID': 'S1',
             'SeriesUID': 'Se1',
             'InstanceUID': 'I1',
+            'AnonStudyUID': '2.25.111',
+            'AnonSeriesUID': '2.25.222',
+            'AnonSOPInstanceUID': '2.25.333',
             'PhysicalDeltaX': 0.1,
             'PhysicalDeltaY': 0.1,
             'ContentDate': '20240101',
@@ -1775,6 +1865,30 @@ class TestBuildCsvDataframe:
         df_no_slash = manager.build_csv_dataframe(self.ROOT)
 
         assert df_slash.iloc[0]['InputPath'] == df_no_slash.iloc[0]['InputPath']
+
+    def test_anon_uid_columns_pass_through_unchanged(self, manager):
+        """Anon* UID columns are persisted verbatim — not subject to the InputPath relative rewrite."""
+        abs_path = os.path.join(self.ROOT, 'a', 'IM001.dcm')
+        self._populate(manager, [self._make_row(abs_path)])
+
+        df = manager.build_csv_dataframe(self.ROOT)
+
+        assert 'AnonStudyUID' in df.columns
+        assert 'AnonSeriesUID' in df.columns
+        assert 'AnonSOPInstanceUID' in df.columns
+        assert df.iloc[0]['AnonStudyUID'] == '2.25.111'
+        assert df.iloc[0]['AnonSeriesUID'] == '2.25.222'
+        assert df.iloc[0]['AnonSOPInstanceUID'] == '2.25.333'
+
+    def test_dataframe_columns_match_constant_ordering(self, manager):
+        """build_csv_dataframe preserves DICOM_DATAFRAME_COLUMNS ordering minus DICOMDataset."""
+        abs_path = os.path.join(self.ROOT, 'a', 'IM001.dcm')
+        self._populate(manager, [self._make_row(abs_path)])
+
+        df = manager.build_csv_dataframe(self.ROOT)
+
+        expected = [c for c in DicomFileManager.DICOM_DATAFRAME_COLUMNS if c != 'DICOMDataset']
+        assert list(df.columns) == expected
 
 
 if __name__ == "__main__":

--- a/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
+++ b/AnonymizeUltrasound/common/tests/test_dicom_file_manager.py
@@ -2275,7 +2275,8 @@ class TestDicomFileManager:
         result = manager_with_data.save_anonymized_dicom_header(
             current_record,
             output_filename,
-            headers_directory
+            headers_directory,
+            anonymized_dataset=current_record.DICOMDataset,
         )
 
         assert result is not None
@@ -2293,7 +2294,8 @@ class TestDicomFileManager:
         result_path = manager_with_data.save_anonymized_dicom_header(
             current_record,
             output_filename,
-            headers_directory
+            headers_directory,
+            anonymized_dataset=current_record.DICOMDataset,
         )
 
         # Read the JSON file and verify anonymization
@@ -2313,7 +2315,8 @@ class TestDicomFileManager:
         result_path = manager_with_data.save_anonymized_dicom_header(
             current_record,
             output_filename,
-            headers_directory
+            headers_directory,
+            anonymized_dataset=current_record.DICOMDataset,
         )
 
         # Read the JSON file and verify anonymization
@@ -2328,7 +2331,8 @@ class TestDicomFileManager:
         result = manager_with_data.save_anonymized_dicom_header(
             current_record,
             "test.dcm",
-            None
+            None,
+            anonymized_dataset=current_record.DICOMDataset,
         )
 
         assert result is None
@@ -2341,25 +2345,29 @@ class TestDicomFileManager:
             manager_with_data.save_anonymized_dicom_header(
                 current_record,
                 "",
-                headers_directory
+                headers_directory,
+                anonymized_dataset=current_record.DICOMDataset,
             )
 
         with pytest.raises(ValueError, match="Output filename is required"):
             manager_with_data.save_anonymized_dicom_header(
                 current_record,
                 "",
-                headers_directory
+                headers_directory,
+                anonymized_dataset=current_record.DICOMDataset,
             )
 
     def test_save_anonymized_dicom_header_raises_error_when_no_record(self, manager_with_data, temp_dir):
         headers_directory = os.path.join(temp_dir, "headers")
         current_record = None
+        real_record = manager_with_data.dicom_df.iloc[0]
 
         with pytest.raises(ValueError, match="Current DICOM record is required"):
             manager_with_data.save_anonymized_dicom_header(
                 current_record,
                 "test.dcm",
-                headers_directory
+                headers_directory,
+                anonymized_dataset=real_record.DICOMDataset,
             )
 
     def test_save_anonymized_dicom_header_flatten_directory_structure(self, manager_with_data, temp_dir):
@@ -2371,7 +2379,8 @@ class TestDicomFileManager:
         result_path = manager_with_data.save_anonymized_dicom_header(
             current_record,
             "test.dcm",
-            headers_directory
+            headers_directory,
+            anonymized_dataset=current_record.DICOMDataset,
         )
 
         expected_path = os.path.join(headers_directory, "test_DICOMHeader.json")
@@ -2555,6 +2564,361 @@ class TestBuildCsvDataframe:
 
         expected = [c for c in DicomFileManager.DICOM_DATAFRAME_COLUMNS if c != 'DICOMDataset']
         assert list(df.columns) == expected
+
+
+class TestRedScaffolding:
+    """RED scaffolding for the de-id review fixes.
+
+    These tests fail on the current code and pass once the corresponding
+    GREEN step lands. Grouped by reviewer finding so each block can be
+    pointed at its production fix.
+    """
+
+    PATIENT_ID = "REDPATIENT"
+    PATIENT_NAME = "Red^Scaffold^Test"
+    STUDY_UID = "1.2.840.RED.STUDY"
+    SERIES_UID = "1.2.840.RED.SERIES"
+    SOP_INSTANCE_UID = "1.2.840.RED.SOP"
+    SOURCE_FOR_UID = "1.2.840.RED.FOR"
+    ANON_FOR_UID = "2.25.RED.ANONFOR"
+    TRANSDUCER_DATA = "SC6-1s,SERIAL12345"
+    TRANSDUCER_MODEL = "sc6-1s"
+    FILE_NAME = "red_test.dcm"
+
+    @pytest.fixture
+    def manager(self):
+        return DicomFileManager()
+
+    @pytest.fixture
+    def temp_dir(self):
+        d = tempfile.mkdtemp()
+        yield d
+        shutil.rmtree(d)
+
+    def _make_source_ds(self, *, sop_uid=None, series_uid=None,
+                        study_uid=None, for_uid=None,
+                        patient_id=None, patient_name=None,
+                        transducer_data=None):
+        """Build a minimal source DICOM dataset for the RED tests."""
+        helper = TestDicomFileManager()
+        ds = helper.create_test_dicom_file(
+            PatientID=patient_id or self.PATIENT_ID,
+            PatientName=patient_name or self.PATIENT_NAME,
+            StudyInstanceUID=study_uid or self.STUDY_UID,
+            SeriesInstanceUID=series_uid or self.SERIES_UID,
+            SOPInstanceUID=sop_uid or self.SOP_INSTANCE_UID,
+            TransducerData=transducer_data or self.TRANSDUCER_DATA,
+        )
+        ds.FrameOfReferenceUID = for_uid or self.SOURCE_FOR_UID
+        return ds
+
+    @pytest.fixture
+    def manager_with_red_data(self, manager, temp_dir):
+        """Populate manager.dicom_df with one row that has all Anon* columns set."""
+        helper = TestDicomFileManager()
+        ds = self._make_source_ds()
+        filename = manager._generate_filename_from_dicom(ds)
+        filepath = helper.save_dicom_file(ds, temp_dir, filename)
+
+        dicom_data = [{
+            'InputPath': filepath,
+            'OutputPath': os.path.relpath(filepath, temp_dir),
+            'AnonFilename': self.FILE_NAME,
+            'PatientUID': self.PATIENT_ID,
+            'StudyUID': self.STUDY_UID,
+            'SeriesUID': self.SERIES_UID,
+            'InstanceUID': self.SOP_INSTANCE_UID,
+            'AnonStudyUID': remap_uid(self.STUDY_UID),
+            'AnonSeriesUID': remap_uid(self.SERIES_UID),
+            'AnonSOPInstanceUID': remap_uid(self.SOP_INSTANCE_UID),
+            'FrameOfReferenceUID': self.SOURCE_FOR_UID,
+            'AnonFrameOfReferenceUID': self.ANON_FOR_UID,
+            'PhysicalDeltaX': 0.1,
+            'PhysicalDeltaY': 0.15,
+            'ContentDate': "20240101",
+            'ContentTime': "120000",
+            'Patch': False,
+            'TransducerModel': self.TRANSDUCER_MODEL,
+            'DICOMDataset': ds,
+        }]
+
+        manager._create_dataframe(dicom_data)
+        manager._for_map[(self.STUDY_UID, self.SOURCE_FOR_UID)] = self.ANON_FOR_UID
+        manager.current_index = 0
+        return manager
+
+    @pytest.fixture
+    def sample_image_array(self):
+        return np.random.randint(0, 255, (1, 10, 15, 1), dtype=np.uint8)
+
+    # ------------------------------------------------------------------
+    # F1 — _DICOMHeader.json must serialize from the anonymized dataset.
+    # ------------------------------------------------------------------
+
+    def test_save_anonymized_dicom_returns_anonymized_dataset(
+        self, manager_with_red_data, temp_dir, sample_image_array
+    ):
+        """save_anonymized_dicom must return the in-memory anonymized DS so
+        the header sidecar can serialize from the same source of truth as the
+        saved .dcm. Currently returns None — RED."""
+        output_path = os.path.join(temp_dir, "out.dcm")
+        # _populate_anon_for_column mints the actual run-local FOR UID
+        # during _create_dataframe; assert against whatever it minted, not a
+        # fixture sentinel.
+        expected_anon_for = manager_with_red_data.dicom_df.iloc[0]['AnonFrameOfReferenceUID']
+        result = manager_with_red_data.save_anonymized_dicom(
+            sample_image_array, output_path,
+            new_patient_name="anon_pt", new_patient_id="ANON_PID"
+        )
+
+        assert isinstance(result, pydicom.Dataset)
+        assert result.PatientID == "ANON_PID"
+        assert result.SOPInstanceUID == remap_uid(self.SOP_INSTANCE_UID)
+        assert result.StudyInstanceUID == remap_uid(self.STUDY_UID)
+        assert result.SeriesInstanceUID == remap_uid(self.SERIES_UID)
+        assert result.FrameOfReferenceUID == expected_anon_for
+        assert result.FrameOfReferenceUID.startswith("2.25.")
+
+    def test_save_anonymized_dicom_header_accepts_anonymized_dataset_kwarg(
+        self, manager_with_red_data, temp_dir, sample_image_array
+    ):
+        """save_anonymized_dicom_header must accept anonymized_dataset kwarg.
+        Currently no such param — RED with TypeError."""
+        headers_dir = os.path.join(temp_dir, "headers")
+        output_path = os.path.join(temp_dir, "out.dcm")
+        anon_ds = manager_with_red_data.save_anonymized_dicom(
+            sample_image_array, output_path,
+            new_patient_name="anon_pt", new_patient_id="ANON_PID"
+        )
+
+        result_path = manager_with_red_data.save_anonymized_dicom_header(
+            manager_with_red_data.dicom_df.iloc[0],
+            "anon_pt.dcm",
+            headers_dir,
+            anonymized_dataset=anon_ds,
+        )
+        assert result_path is not None
+        assert os.path.exists(result_path)
+
+    def test_header_json_does_not_leak_source_uids(
+        self, manager_with_red_data, temp_dir, sample_image_array
+    ):
+        """The header JSON sidecar must contain remapped UIDs and must NOT
+        contain any original source UID values."""
+        headers_dir = os.path.join(temp_dir, "headers")
+        output_path = os.path.join(temp_dir, "out.dcm")
+        expected_anon_for = manager_with_red_data.dicom_df.iloc[0]['AnonFrameOfReferenceUID']
+        anon_ds = manager_with_red_data.save_anonymized_dicom(
+            sample_image_array, output_path,
+            new_patient_name="anon_pt", new_patient_id="ANON_PID"
+        )
+        result_path = manager_with_red_data.save_anonymized_dicom_header(
+            manager_with_red_data.dicom_df.iloc[0],
+            "anon_pt.dcm",
+            headers_dir,
+            anonymized_dataset=anon_ds,
+        )
+
+        with open(result_path) as f:
+            serialized = f.read()
+
+        assert self.STUDY_UID not in serialized
+        assert self.SERIES_UID not in serialized
+        assert self.SOP_INSTANCE_UID not in serialized
+        assert self.SOURCE_FOR_UID not in serialized
+        assert remap_uid(self.STUDY_UID) in serialized
+        assert remap_uid(self.SERIES_UID) in serialized
+        assert remap_uid(self.SOP_INSTANCE_UID) in serialized
+        assert expected_anon_for in serialized
+
+    def test_header_json_uses_trimmed_transducer_data(
+        self, manager_with_red_data, temp_dir, sample_image_array
+    ):
+        """The header JSON sidecar must contain only the trimmed first
+        segment of TransducerData. The source's vendor serial number must
+        not leak."""
+        headers_dir = os.path.join(temp_dir, "headers")
+        output_path = os.path.join(temp_dir, "out.dcm")
+        anon_ds = manager_with_red_data.save_anonymized_dicom(
+            sample_image_array, output_path,
+            new_patient_name="anon_pt", new_patient_id="ANON_PID"
+        )
+        result_path = manager_with_red_data.save_anonymized_dicom_header(
+            manager_with_red_data.dicom_df.iloc[0],
+            "anon_pt.dcm",
+            headers_dir,
+            anonymized_dataset=anon_ds,
+        )
+
+        with open(result_path) as f:
+            serialized = f.read()
+
+        assert "SERIAL12345" not in serialized
+        assert "SC6-1s" in serialized
+
+    # ------------------------------------------------------------------
+    # F4 — _for_map must be cleared at start of each scan_directory call.
+    # ------------------------------------------------------------------
+
+    def test_scan_directory_clears_for_map_between_unrelated_scans(self, temp_dir):
+        """Two scans of unrelated studies on one DicomFileManager must NOT
+        share _for_map entries. Currently entries from scan #1 persist into
+        scan #2 — RED."""
+        helper = TestDicomFileManager()
+
+        # Scan 1 input.
+        scan1_dir = os.path.join(temp_dir, "scan1")
+        os.makedirs(scan1_dir)
+        ds1 = helper.create_test_dicom_file(
+            StudyInstanceUID="1.2.RED.STUDY.A",
+            SeriesInstanceUID="1.2.RED.SER.A",
+            SOPInstanceUID="1.2.RED.SOP.A",
+        )
+        ds1.FrameOfReferenceUID = "1.2.RED.FOR.A"
+        helper.save_dicom_file(ds1, scan1_dir, "a.dcm")
+
+        # Scan 2 input — completely different study.
+        scan2_dir = os.path.join(temp_dir, "scan2")
+        os.makedirs(scan2_dir)
+        ds2 = helper.create_test_dicom_file(
+            StudyInstanceUID="1.2.RED.STUDY.B",
+            SeriesInstanceUID="1.2.RED.SER.B",
+            SOPInstanceUID="1.2.RED.SOP.B",
+        )
+        ds2.FrameOfReferenceUID = "1.2.RED.FOR.B"
+        helper.save_dicom_file(ds2, scan2_dir, "b.dcm")
+
+        m = DicomFileManager()
+        m.scan_directory(scan1_dir)
+        scan1_keys = set(m._for_map.keys())
+        assert ("1.2.RED.STUDY.A", "1.2.RED.FOR.A") in scan1_keys
+
+        # Re-scan a different directory on the same manager.
+        m.scan_directory(scan2_dir)
+
+        # After scan #2, _for_map must contain ONLY scan #2's entries.
+        # Currently scan #1's entries persist — RED.
+        assert ("1.2.RED.STUDY.A", "1.2.RED.FOR.A") not in m._for_map
+        assert ("1.2.RED.STUDY.B", "1.2.RED.FOR.B") in m._for_map
+
+    def test_scan_directory_remints_anon_for_when_rescanning_same_study(self, temp_dir):
+        """Run-local unlinkability: scanning the same study twice on one manager
+        without seed_keys_csv must yield a different anonymized FOR UID the
+        second time. Currently the second scan reuses the first scan's
+        _for_map entry — RED."""
+        helper = TestDicomFileManager()
+        ds = helper.create_test_dicom_file(
+            StudyInstanceUID="1.2.RED.STUDY.RESCAN",
+            SeriesInstanceUID="1.2.RED.SER.RESCAN",
+            SOPInstanceUID="1.2.RED.SOP.RESCAN",
+        )
+        ds.FrameOfReferenceUID = "1.2.RED.FOR.RESCAN"
+        helper.save_dicom_file(ds, temp_dir, "rescan.dcm")
+
+        m = DicomFileManager()
+        m.scan_directory(temp_dir)
+        first_anon = m.dicom_df.iloc[0]['AnonFrameOfReferenceUID']
+
+        # Re-scan the same directory on the same manager — no seed.
+        m.scan_directory(temp_dir)
+        second_anon = m.dicom_df.iloc[0]['AnonFrameOfReferenceUID']
+
+        assert first_anon != second_anon
+        assert first_anon.startswith("2.25.")
+        assert second_anon.startswith("2.25.")
+
+    def test_scan_directory_preserves_seeded_mapping_after_reset(self, temp_dir):
+        """Reset-then-seed ordering must not break the resume contract:
+        when a seed_keys_csv is provided, the seeded entries survive the
+        reset and the second scan reuses them."""
+        helper = TestDicomFileManager()
+        ds = helper.create_test_dicom_file(
+            StudyInstanceUID="1.2.RED.STUDY.RESUME",
+            SeriesInstanceUID="1.2.RED.SER.RESUME",
+            SOPInstanceUID="1.2.RED.SOP.RESUME",
+        )
+        ds.FrameOfReferenceUID = "1.2.RED.FOR.RESUME"
+        helper.save_dicom_file(ds, temp_dir, "resume.dcm")
+
+        m1 = DicomFileManager()
+        m1.scan_directory(temp_dir)
+        prior_anon = m1.dicom_df.iloc[0]['AnonFrameOfReferenceUID']
+        prior_keys = os.path.join(temp_dir, "keys.csv")
+        m1.build_csv_dataframe(temp_dir).to_csv(prior_keys, index=False)
+
+        # Second scan on a DIFFERENT manager with the seed CSV.
+        m2 = DicomFileManager()
+        # Pre-pollute m2._for_map with stale entries to verify they get cleared
+        # before seeding so they don't shadow seeded mappings.
+        m2._for_map[("1.2.STALE.STUDY", "1.2.STALE.FOR")] = "2.25.STALE"
+        m2.scan_directory(temp_dir, seed_keys_csv=prior_keys)
+
+        rescanned_anon = m2.dicom_df.iloc[0]['AnonFrameOfReferenceUID']
+        assert rescanned_anon == prior_anon
+        # Stale entry must have been cleared by the reset-then-seed sequence.
+        assert ("1.2.STALE.STUDY", "1.2.STALE.FOR") not in m2._for_map
+
+    # ------------------------------------------------------------------
+    # F5 — PatientAge calendar-year math at the exact one-year boundary.
+    # ------------------------------------------------------------------
+
+    def test_compute_patient_age_returns_001y_at_exact_one_year(self, manager_with_red_data):
+        """A patient exactly 365 days old (no leap year between dates) is one
+        calendar year old and must yield '001Y'. Current `int(365 // 365.25)`
+        returns 0 → '000Y' — RED."""
+        ds = pydicom.Dataset()
+        source_ds = pydicom.Dataset()
+        source_ds.PatientID = "REDPATIENT"
+        source_ds.PatientBirthDate = "20210601"  # 2021 non-leap
+        source_ds.StudyDate = "20220601"          # exactly 365 days later
+
+        manager_with_red_data._apply_anonymization(ds, source_ds)
+
+        assert ds.PatientAge == "001Y"
+
+    def test_compute_patient_age_handles_leap_spanning_one_year(self, manager_with_red_data):
+        """A patient born 2020-02-15 and studied 2021-02-15 spans a leap day
+        (delta_days = 366). Both old and new math return '001Y'; this guards
+        against accidentally over-correcting."""
+        ds = pydicom.Dataset()
+        source_ds = pydicom.Dataset()
+        source_ds.PatientID = "REDPATIENT"
+        source_ds.PatientBirthDate = "20200215"
+        source_ds.StudyDate = "20210215"
+
+        manager_with_red_data._apply_anonymization(ds, source_ds)
+
+        assert ds.PatientAge == "001Y"
+
+    def test_compute_patient_age_returns_months_when_birthday_not_yet(
+        self, manager_with_red_data
+    ):
+        """Birthday hasn't arrived yet: 2020-06-01 → 2021-05-31 is 364 days.
+        Falls into the months branch with current code (`< 365`) and must
+        keep doing so after the fix."""
+        ds = pydicom.Dataset()
+        source_ds = pydicom.Dataset()
+        source_ds.PatientID = "REDPATIENT"
+        source_ds.PatientBirthDate = "20200601"
+        source_ds.StudyDate = "20210531"
+
+        manager_with_red_data._apply_anonymization(ds, source_ds)
+
+        # 364 / 30.4375 ≈ 11.96 → 11M (current behavior is correct here).
+        assert ds.PatientAge == "011M"
+
+    def test_compute_patient_age_at_two_years_exact(self, manager_with_red_data):
+        """delta_days = 731 (one leap year between 2-year span) must yield
+        '002Y'. Regression test for the years branch under the new math."""
+        ds = pydicom.Dataset()
+        source_ds = pydicom.Dataset()
+        source_ds.PatientID = "REDPATIENT"
+        source_ds.PatientBirthDate = "20190601"
+        source_ds.StudyDate = "20210601"  # 2020 was a leap year → 731 days
+
+        manager_with_red_data._apply_anonymization(ds, source_ds)
+
+        assert ds.PatientAge == "002Y"
 
 
 if __name__ == "__main__":

--- a/AnonymizeUltrasound/common/tests/test_dicom_processor.py
+++ b/AnonymizeUltrasound/common/tests/test_dicom_processor.py
@@ -1,0 +1,183 @@
+"""Tests for DicomProcessor — focused on sidecar correctness invariants.
+
+The full processor exercises model inference and masking; those paths are
+covered by integration/E2E. Here we test the small, deterministic helpers
+that emit sidecar files, where source-vs-anonymized UID confusion can leak
+PHI.
+
+`dicom_processor` imports torch and matplotlib at module load time for the
+inference / PDF-overview paths. The sidecar helper under test does not
+touch either; we stub them via sys.modules so the test can run in a slim
+venv without torch installed.
+"""
+import json
+import os
+import sys
+import tempfile
+import shutil
+import types
+
+import pytest
+
+
+class _PermissiveStubModule(types.ModuleType):
+    """Module that returns a dummy object for every attribute access.
+
+    dicom_processor (and its imports) reference symbols from torch / cv2 /
+    monai / matplotlib at module load time (type annotations, constants).
+    We don't execute any of those code paths in the sidecar tests, so a
+    permissive stub keeps imports cheap without faking real APIs.
+    """
+
+    def __getattr__(self, attr):  # noqa: D401
+        return type(attr, (), {})
+
+
+def _stub_module(name: str) -> types.ModuleType:
+    """Install a permissive stub under `name` so `import name` succeeds."""
+    if name in sys.modules:
+        return sys.modules[name]
+    mod = _PermissiveStubModule(name)
+    sys.modules[name] = mod
+    return mod
+
+
+for _name in (
+    "torch",
+    "cv2",
+    "requests",
+    "monai",
+    "monai.metrics",
+    "monai.metrics.meandice",
+    "monai.metrics.meaniou",
+    "matplotlib",
+    "matplotlib.pyplot",
+    "matplotlib.patches",
+    "matplotlib.backends",
+    "matplotlib.backends.backend_pdf",
+):
+    _stub_module(_name)
+
+# evaluation.py uses non-relative `from common.masking import create_mask`,
+# which only resolves when AnonymizeUltrasound/ is on sys.path.
+_anon_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _anon_dir not in sys.path:
+    sys.path.insert(0, _anon_dir)
+
+from ..dicom_processor import DicomProcessor, ProcessingConfig  # noqa: E402
+from ..dicom_file_manager import DicomFileManager  # noqa: E402
+
+
+class _DataframeRow:
+    """Lightweight stand-in for a pandas dataframe row.
+
+    `_save_sequence_info` uses both `row.DICOMDataset.SOPInstanceUID` (the
+    bug) and `row.AnonSOPInstanceUID` (the fix). A simple attribute-bag is
+    sufficient — no pandas required.
+    """
+
+    def __init__(self, *, anon_sop_uid: str, source_sop_uid: str):
+        self.AnonSOPInstanceUID = anon_sop_uid
+
+        class _DS:
+            pass
+
+        ds = _DS()
+        ds.SOPInstanceUID = source_sop_uid
+        self.DICOMDataset = ds
+
+
+@pytest.fixture
+def temp_dir():
+    d = tempfile.mkdtemp()
+    yield d
+    shutil.rmtree(d)
+
+
+@pytest.fixture
+def processor():
+    """Minimal processor wired up enough to call _save_sequence_info.
+
+    No model is loaded; the helper under test does not touch the model.
+    """
+    config = ProcessingConfig(
+        model_path="",
+        device="cpu",
+        no_mask_generation=False,
+        phi_only_mode=False,
+    )
+    return DicomProcessor(config, DicomFileManager())
+
+
+class TestSaveSequenceInfoNoSopUidLeak:
+    """F2 — _save_sequence_info must write the anonymized SOPInstanceUID.
+
+    Currently it writes `row.DICOMDataset.SOPInstanceUID` (the source UID),
+    creating a sidecar leak next to the anonymized .dcm.
+    """
+
+    SOURCE_SOP_UID = "1.2.840.SOURCE.SOP.LEAK"
+    ANON_SOP_UID = "2.25.ANON.SOP.SAFE"
+
+    def test_sequence_info_uses_anon_sop_uid_not_source(self, processor, temp_dir):
+        """The JSON sidecar's SOPInstanceUID must equal row.AnonSOPInstanceUID,
+        NOT row.DICOMDataset.SOPInstanceUID."""
+        row = _DataframeRow(
+            anon_sop_uid=self.ANON_SOP_UID,
+            source_sop_uid=self.SOURCE_SOP_UID,
+        )
+        final_output_path = os.path.join(temp_dir, "out.dcm")
+
+        processor._save_sequence_info(final_output_path, row, mask_config=None)
+
+        json_path = final_output_path.replace(".dcm", ".json")
+        assert os.path.exists(json_path)
+        with open(json_path) as f:
+            payload = json.load(f)
+
+        assert payload["SOPInstanceUID"] == self.ANON_SOP_UID
+        assert payload["SOPInstanceUID"] != self.SOURCE_SOP_UID
+
+    def test_sequence_info_no_source_uid_in_payload(self, processor, temp_dir):
+        """Belt-and-suspenders: the source UID string must not appear ANYWHERE
+        in the serialized JSON."""
+        row = _DataframeRow(
+            anon_sop_uid=self.ANON_SOP_UID,
+            source_sop_uid=self.SOURCE_SOP_UID,
+        )
+        final_output_path = os.path.join(temp_dir, "out.dcm")
+
+        processor._save_sequence_info(final_output_path, row, mask_config=None)
+
+        json_path = final_output_path.replace(".dcm", ".json")
+        with open(json_path) as f:
+            serialized = f.read()
+
+        assert self.SOURCE_SOP_UID not in serialized
+        assert self.ANON_SOP_UID in serialized
+
+    def test_sequence_info_falls_back_to_none_when_anon_sop_uid_missing(
+        self, processor, temp_dir
+    ):
+        """If AnonSOPInstanceUID is empty (degenerate input), the sidecar must
+        write 'None' — never the source UID."""
+        row = _DataframeRow(
+            anon_sop_uid="",
+            source_sop_uid=self.SOURCE_SOP_UID,
+        )
+        final_output_path = os.path.join(temp_dir, "out.dcm")
+
+        processor._save_sequence_info(final_output_path, row, mask_config=None)
+
+        json_path = final_output_path.replace(".dcm", ".json")
+        with open(json_path) as f:
+            payload = json.load(f)
+
+        assert payload["SOPInstanceUID"] == "None"
+        with open(json_path) as f:
+            serialized = f.read()
+        assert self.SOURCE_SOP_UID not in serialized
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/AnonymizeUltrasound/common/tests/test_uid_remap.py
+++ b/AnonymizeUltrasound/common/tests/test_uid_remap.py
@@ -1,0 +1,66 @@
+"""Tests for the pure remap_uid helper used by the DICOM de-id pipeline."""
+
+import hashlib
+import re
+
+import pytest
+
+from ..uid_remap import remap_uid
+
+
+SAMPLE_SOURCE_UIDS = [
+    "1.2.840.113619.2.55.3.604688432.781.1591781234.467",
+    "1.2.840.113619.2.55.3.604688432.781.1591781234.468",
+    "1.2.840.10008.5.1.4.1.1.6.1",
+    "1.2.276.0.7230010.3.1.4.0.4242.20240101120000.1",
+]
+
+
+def _expected_remap(orig: str) -> str:
+    digest = hashlib.sha256(orig.encode("ascii")).digest()[:15]
+    return f"2.25.{int.from_bytes(digest, 'big')}"
+
+
+@pytest.mark.parametrize("src", SAMPLE_SOURCE_UIDS)
+def test_remap_uid_matches_specification(src):
+    """remap_uid must use sha256, truncate to 15 bytes, big-endian int, '2.25.' arc."""
+    assert remap_uid(src) == _expected_remap(src)
+
+
+def test_remap_uid_is_deterministic():
+    src = SAMPLE_SOURCE_UIDS[0]
+    assert remap_uid(src) == remap_uid(src)
+
+
+@pytest.mark.parametrize("src", SAMPLE_SOURCE_UIDS)
+def test_remap_uid_starts_with_2_25_arc(src):
+    assert remap_uid(src).startswith("2.25.")
+
+
+@pytest.mark.parametrize("src", SAMPLE_SOURCE_UIDS)
+def test_remap_uid_format_is_2_25_dot_digits(src):
+    assert re.fullmatch(r"2\.25\.\d+", remap_uid(src)) is not None
+
+
+@pytest.mark.parametrize("src", SAMPLE_SOURCE_UIDS)
+def test_remap_uid_length_within_dicom_ui_limit(src):
+    """DICOM UI VR limit is 64 characters."""
+    assert len(remap_uid(src)) <= 64
+
+
+def test_remap_uid_distinct_inputs_produce_distinct_outputs():
+    outputs = {remap_uid(u) for u in SAMPLE_SOURCE_UIDS}
+    assert len(outputs) == len(SAMPLE_SOURCE_UIDS)
+
+
+def test_remap_uid_handles_empty_string():
+    """Empty source should hash without error and stay in the 2.25 arc."""
+    result = remap_uid("")
+    assert result == _expected_remap("")
+    assert result.startswith("2.25.")
+
+
+def test_remap_uid_handles_pydicom_generated_uid_format():
+    """remap_uid must accept pydicom-style UIDs (the generate_uid fallback path)."""
+    pydicom_style = "1.2.826.0.1.3680043.8.498.123456789012345678901234567890"
+    assert remap_uid(pydicom_style) == _expected_remap(pydicom_style)

--- a/AnonymizeUltrasound/common/uid_remap.py
+++ b/AnonymizeUltrasound/common/uid_remap.py
@@ -1,0 +1,15 @@
+"""Deterministic DICOM UID remapping for the AnonymizeUltrasound de-id pipeline.
+
+Anonymized UIDs live in the OID arc ``2.25.`` (ITU-T X.667 / ISO-IEC 9834-8),
+which permits UUID-derived UIDs without organizational registration. The
+deterministic SHA-256 input means the same source UID always produces the
+same anonymized UID — satisfying DICOM PS3.15 E.1.1 action ``U``'s "internally
+consistent within a set of Instances" requirement without a session cache.
+"""
+
+import hashlib
+
+
+def remap_uid(orig_uid: str) -> str:
+    digest = hashlib.sha256(orig_uid.encode("ascii")).digest()[:15]
+    return f"2.25.{int.from_bytes(digest, 'big')}"

--- a/AnonymizeUltrasound/scripts/README.md
+++ b/AnonymizeUltrasound/scripts/README.md
@@ -153,7 +153,8 @@ python -m auto_anonymize \
 - **Patient name/ID:** Cleared or hashed (SHA-256)
 - **Birth date:** Truncated to year only
 - **Dates:** Randomly shifted ≤30 days (consistent per patient)
-- **UIDs:** SOP/Study/SeriesInstanceUID passed through from source when present; fresh UIDs generated only if missing
+- **UIDs:** SOP/Study/SeriesInstanceUID are remapped deterministically into the `2.25.` OID arc (`2.25.<int>` derived from SHA-256 of the source UID). The original→anonymized mapping is recorded in `keys.csv` columns `AnonStudyUID`, `AnonSeriesUID`, `AnonSOPInstanceUID`. SOPClassUID is preserved verbatim (it identifies the registered DICOM object type).
+- **TransducerData (0018,5010):** Only the leading model segment is kept (e.g. `SC6-1s,JK9` → `SC6-1s`); vendor serial numbers after the first `,` or `\` are dropped.
 - **Encoding:** Re-encoded with JPEG baseline compression
 
 #### Exit Codes

--- a/AnonymizeUltrasound/scripts/auto_anonymize.py
+++ b/AnonymizeUltrasound/scripts/auto_anonymize.py
@@ -121,8 +121,21 @@ def main():
     processor.initialize_model()
     overview_manifest = []
 
-    # Scan directory
-    num_files = dicom_manager.scan_directory(args.input_dir, config.skip_single_frame, config.hash_patient_id)
+    # Scan directory. On resume (when args.headers_dir already contains a
+    # keys.csv from a prior run), seed scan_directory with that CSV so the
+    # (StudyUID, FrameOfReferenceUID) → AnonFrameOfReferenceUID mapping is
+    # preserved. Without this, previously-exported files keep their old
+    # anon FOR while newly-processed files get a fresh one, and the rewritten
+    # keys.csv would no longer match the on-disk .dcm contents.
+    prior_keys_csv = None
+    if args.headers_dir:
+        candidate = os.path.join(args.headers_dir, 'keys.csv')
+        if os.path.exists(candidate):
+            prior_keys_csv = candidate
+    num_files = dicom_manager.scan_directory(
+        args.input_dir, config.skip_single_frame, config.hash_patient_id,
+        seed_keys_csv=prior_keys_csv,
+    )
     logger.info(f"Found {num_files} DICOM files")
 
     # Save keys.csv


### PR DESCRIPTION
## Summary
- AnonymizeUltrasound now regenerates Study, Series, and SOP Instance UIDs deterministically (`2.25.<sha256[:15]>`) instead of passing the source values through; the original->anonymized mapping is recorded in three new `keys.csv` columns (`AnonStudyUID`, `AnonSeriesUID`, `AnonSOPInstanceUID`).
- `FrameOfReferenceUID` (0020,0052) is anonymized per (source StudyUID, source FOR UID) group with run-local generation via `pydicom.uid.generate_uid(prefix=None)`:
   - Two source series in one study sharing a FOR UID get the SAME output FOR UID (downstream multi-series registration / volumetric fusion works).
   - Two studies that happen to share a source FOR UID get DIFFERENT output FOR UIDs (cross-study unlinkability).
   - Two independent de-id runs over identical input produce DIFFERENT output FOR UIDs (cross-export unlinkability — run-local, non-deterministic generation).
   - Coordinate-less source series within one study are NOT falsely linked to each other.
   - The source value is never copied or hashed; the field is always set on output (Type 1/1C compliance for US IODs).
   - Two new `keys.csv` columns (`FrameOfReferenceUID`, `AnonFrameOfReferenceUID`) record the mapping; `scan_directory(seed_keys_csv=...)` accepts a prior export's `keys.csv` to reuse mappings for a resumed export. Older `keys.csv` files without the new columns are accepted as a graceful no-op.
- `PatientAge` (0010,1010) is now computed from `StudyDate - PatientBirthDate` when the source has no `PatientAge`, so the demographic survives de-id even when the source only encoded `PatientBirthDate`. Units are picked by magnitude (`<31 days -> nnnD`, `<365 days -> nnnM` using 30.4375 days/month, else `nnnY` using calendar-year arithmetic). HIPAA Safe Harbor §164.514(b)(2)(i)(C) cap at `090Y` applies to both source-provided and computed years. Source `PatientAge` always wins — no overwrite. Falls back to leaving `PatientAge` absent (warning logged) when neither source path is usable. `PatientBirthDate` itself is still cleared to `""` on the de-id output.
- `TransducerData` (0018,5010) on the de-id DICOM is reduced to the leading model segment (e.g. `SC6-1s,JK9` -> `SC6-1s`), so vendor serial numbers no longer leak through that tag.
- `Manufacturer` (0008,0070) and `ManufacturerModelName` (0008,1090) are preserved verbatim; new regression tests lock that behavior so future refactors cannot drop them.
- Out of scope: PatientIdentityRemoved / DeidentificationMethod tags, Group 0004 stripping, preamble replacement. These are known DICOM PS3.15 E.1.1 conformance gaps and remain follow-up work.
- Address P1 review comment: also ship `common/uid_remap.py` from the Slicer extension build by adding it to `MODULE_PYTHON_SCRIPTS` in `AnonymizeUltrasound/CMakeLists.txt`. Without this, packaged installs would hit `ModuleNotFoundError: common.uid_remap` when loading `common.dicom_file_manager` (which imports `remap_uid` relatively).

## Review-fix commit `a839d37`

A second-pass code review of the deid-changes branch flagged five issues against the artifact-set de-id invariant — two PHI leaks in JSON sidecars, two FrameOfReferenceUID policy violations, and a PatientAge off-by-one at the exact one-year boundary. All are fixed in commit `a839d37`:

- **F1 (Critical) — `_DICOMHeader.json` no longer leaks source UIDs, FrameOfReferenceUID, or untrimmed TransducerData.** `save_anonymized_dicom` now returns the in-memory anonymized `pydicom.Dataset`, and `save_anonymized_dicom_header` requires an `anonymized_dataset` kwarg from which it serializes the JSON. Both the CLI (`dicom_processor.py:_process_dicom_file`) and the Slicer single-file path (`AnonymizeUltrasound.py:exportDicom`) thread the anonymized Dataset through. The existing `output_filename`-based patient-name override and partial birth-date scrub are preserved.
- **F2 (Critical) — The sequence-info JSON sidecar's `SOPInstanceUID` field now reads `row.AnonSOPInstanceUID`** (the remapped UID already populated at scan time), in both `dicom_processor._save_sequence_info` and the Slicer `exportDicom()` flow. Previously it read `row.DICOMDataset.SOPInstanceUID` — the source UID — leaving a second sidecar leak next to the anonymized `.dcm`.
- **F3 (Important) — `auto_anonymize.py` (CLI) and `AnonymizeUltrasound.py:batch_auto_anonymize` (Slicer batch) now wire `seed_keys_csv` through to `scan_directory`.** Both call sites compute `prior_keys_csv = <headers_dir>/keys.csv if exists else None` before calling `scan_directory`. This closes the gap where a resumed export would mint fresh anon FOR UIDs for new files while previously-exported files kept the old ones, leaving `keys.csv` inconsistent with the on-disk `.dcm`s.
- **F4 (Important) — `scan_directory` resets `_for_map = {}` before seeding from `seed_keys_csv`.** A long-lived `DicomFileManager` (the Slicer `AnonymizeUltrasoundLogic` singleton holds one for the whole app session) used to carry per-study FOR mappings across unrelated scans, breaking run-local unlinkability. The reset-then-seed order preserves the resume contract because `_seed_for_map_from_keys_csv` uses `setdefault`.
- **F5 (Important) — `_compute_patient_age_from_birthdate`'s years branch now uses calendar arithmetic** (`years = study_date.year - birth_date.year`, decremented if `(month, day)` hasn't reached the birthday) instead of `int(delta_days // 365.25)`. A patient exactly 365 days old (no leap year between dates) now reports `001Y` instead of `000Y`.

**New tests** (14 added; the 11 RED tests fail on the parent commit `fbcbb11` and pass on `a839d37`):

- `test_dicom_file_manager.py::TestRedScaffolding` — 11 tests covering: header sidecar no-source-UID-leak, header sidecar TransducerData trim, `save_anonymized_dicom` return contract, `_for_map` reset between unrelated scans on one manager, re-mint on same-study re-scan, seeded-mapping preservation after reset, calendar-year PatientAge at the exact one-year boundary (`001Y` at 365 days), plus regression guards for leap-spanning one year and birthday-not-yet boundaries.
- `test_dicom_processor.py` (new file) — 3 tests covering the sequence-info JSON SOP UID path, including the `'None'` fallback for missing `AnonSOPInstanceUID`. Uses a permissive sys.modules stub for `torch` / `cv2` / `monai` / `matplotlib` so the helper-under-test can be exercised without the full ML stack.

## Manual E2E Testing

**Prerequisites:**
- Python 3.9+ (developed against CPython 3.13.9)
- `uv` (recommended) or `pip`
- macOS, Linux, or WSL
- `git` and a checkout of this PR's branch

**Setup from a clean checkout:**
```bash
git clone git@github.com:SlicerUltrasound/SlicerUltrasound.git
cd SlicerUltrasound
git fetch origin
gh pr checkout 185           # or: git fetch <fork> worktree-deid-changes && git checkout FETCH_HEAD
uv venv --python 3.13 .venv
uv pip install -p .venv -r requirements-test.txt
```

**Steps to exercise the change:**

1. Run the targeted unit tests for the changed module:
   ```bash
   .venv/bin/pytest AnonymizeUltrasound/common/tests/ -q
   ```
   Pass criteria: 198 passed.

2. Run the broader pure-Python suites that exercise the module externally:
   ```bash
   .venv/bin/pytest AnonymizeUltrasound/tests/ -q
   .venv/bin/pytest tests/ -q
   ```
   Pass criteria: 9 passed and 37 passed respectively.

3. (Optional) Exercise the UID + TransducerData behavior interactively against a synthetic DICOM fixture:
   ```bash
   .venv/bin/python - <<'PY'
   import os, tempfile
   from AnonymizeUltrasound.common.dicom_file_manager import DicomFileManager
   from AnonymizeUltrasound.common.uid_remap import remap_uid

   mgr = DicomFileManager()
   from AnonymizeUltrasound.common.tests.test_dicom_file_manager import TestDicomFileManager
   helper = TestDicomFileManager()
   with tempfile.TemporaryDirectory() as tmp:
       ds = helper.create_test_dicom_file(TransducerData="SP5-1s,CB3C")
       fname = mgr._generate_filename_from_dicom(ds)
       fpath = helper.save_dicom_file(ds, tmp, fname)
       row = mgr._extract_dicom_info(fpath, tmp, False)
       print("source StudyUID     :", row['StudyUID'])
       print("anonymized StudyUID :", row['AnonStudyUID'])
       print("deterministic match :", row['AnonStudyUID'] == remap_uid(row['StudyUID']))
       print("starts with 2.25.   :", row['AnonStudyUID'].startswith("2.25."))
   PY
   ```
   Pass criteria: prints `deterministic match : True` and `starts with 2.25.   : True`.

4. (Optional) Exercise the new per-study run-local `FrameOfReferenceUID` policy against synthetic source data:
   ```bash
   .venv/bin/python - <<'PY'
   import os, tempfile
   from AnonymizeUltrasound.common.dicom_file_manager import DicomFileManager
   from AnonymizeUltrasound.common.uid_remap import remap_uid
   from AnonymizeUltrasound.common.tests.test_dicom_file_manager import TestDicomFileManager
   helper = TestDicomFileManager()

   def write(tmp, subdir, sop, ser, study, for_uid, patient='P1'):
       d = os.path.join(tmp, subdir); os.makedirs(d, exist_ok=True)
       ds = helper.create_test_dicom_file(
           SOPInstanceUID=sop, SeriesInstanceUID=ser,
           StudyInstanceUID=study, PatientID=patient)
       ds.FrameOfReferenceUID = for_uid
       fname = f"{sop.replace('.', '_')}.dcm"
       helper.save_dicom_file(ds, d, fname)

   with tempfile.TemporaryDirectory() as tmp:
       # Two series in Study1 share source FOR; Study2 incidentally shares the SAME source FOR.
       write(tmp, 'study1/a', '1.2.A.1', '1.2.SER.A', '1.2.STUDY.ONE', '1.2.FOR.SHARED')
       write(tmp, 'study1/b', '1.2.A.2', '1.2.SER.B', '1.2.STUDY.ONE', '1.2.FOR.SHARED')
       write(tmp, 'study2/a', '1.2.B.1', '1.2.SER.C', '1.2.STUDY.TWO', '1.2.FOR.SHARED', patient='P2')

       m = DicomFileManager()
       m.scan_directory(tmp)
       df = m.dicom_df
       s1 = df[df.StudyUID == '1.2.STUDY.ONE'].AnonFrameOfReferenceUID.unique()
       s2 = df[df.StudyUID == '1.2.STUDY.TWO'].AnonFrameOfReferenceUID.unique()
       print("within-study shared :", len(s1) == 1)
       print("cross-study differs :", s1[0] != s2[0])
       print("anon starts 2.25.   :", s1[0].startswith("2.25.") and s2[0].startswith("2.25."))
       print("source FOR no leak  :", '1.2.FOR.SHARED' not in {s1[0], s2[0]})
       print("source FOR no hash  :", remap_uid('1.2.FOR.SHARED') not in {s1[0], s2[0]})

   # Second independent run — must yield different anon FORs (run-local).
   with tempfile.TemporaryDirectory() as tmp:
       write(tmp, 'study1/a', '1.2.A.1', '1.2.SER.A', '1.2.STUDY.ONE', '1.2.FOR.SHARED')
       m2 = DicomFileManager()
       m2.scan_directory(tmp)
       new_anon = m2.dicom_df.iloc[0].AnonFrameOfReferenceUID
       print("run-local (rerun)   :", new_anon.startswith("2.25.") and new_anon != s1[0])
   PY
   ```
   Pass criteria: all five lines print `True`.

5. (Optional) Exercise the new `PatientAge` compute path:
   ```bash
   .venv/bin/python - <<'PY'
   import pydicom
   from AnonymizeUltrasound.common.dicom_file_manager import DicomFileManager

   mgr = DicomFileManager()
   src = pydicom.Dataset()
   src.PatientID            = "P1"
   src.PatientBirthDate     = "19800101"
   src.StudyDate            = "20200101"

   out = pydicom.Dataset()
   mgr._apply_anonymization(out, src)

   print("PatientAge computed :", out.PatientAge == "040Y")
   print('PatientBirthDate "" :', out.PatientBirthDate == "")
   PY
   ```
   Pass criteria: both lines print `True`.

6. (Optional, **review-fix commit only**) Exercise the resume + `_for_map` reset behavior added in `a839d37`:
   ```bash
   .venv/bin/python - <<'PY'
   import os, sys, tempfile, shutil
   sys.path.insert(0, "AnonymizeUltrasound")
   from common.dicom_file_manager import DicomFileManager
   from pydicom.dataset import FileDataset, FileMetaDataset

   def make_dcm(out_dir, sop, ser, study, for_uid, name):
       meta = FileMetaDataset()
       meta.MediaStorageSOPClassUID = "1.2.840.10008.5.1.4.1.1.6.1"
       meta.MediaStorageSOPInstanceUID = sop
       meta.ImplementationClassUID = "1.2.826.0.1.3680043.8.498.1"
       meta.TransferSyntaxUID = "1.2.840.10008.1.2"
       ds = FileDataset(None, {}, file_meta=meta, preamble=b"\0"*128)
       ds.PatientID = "P1"; ds.PatientName = "Patient^Name"
       ds.StudyInstanceUID = study; ds.SeriesInstanceUID = ser
       ds.SOPInstanceUID = sop; ds.FrameOfReferenceUID = for_uid
       ds.SOPClassUID = meta.MediaStorageSOPClassUID
       ds.Modality = "US"; ds.NumberOfFrames = 2
       ds.Rows = 4; ds.Columns = 4
       ds.BitsAllocated = 8; ds.BitsStored = 8; ds.HighBit = 7
       ds.PixelRepresentation = 0; ds.SamplesPerPixel = 1
       ds.PhotometricInterpretation = "MONOCHROME2"
       ds.PixelData = b"\x00" * 32
       ds.save_as(os.path.join(out_dir, name))

   tmp = tempfile.mkdtemp()
   try:
       in_dir = os.path.join(tmp, "input"); os.makedirs(in_dir)
       make_dcm(in_dir, "1.2.SOP.A", "1.2.SER.A", "1.2.STUDY.X", "1.2.FOR.S", "a.dcm")
       make_dcm(in_dir, "1.2.SOP.B", "1.2.SER.B", "1.2.STUDY.X", "1.2.FOR.S", "b.dcm")
       headers = os.path.join(tmp, "headers"); os.makedirs(headers)
       m1 = DicomFileManager(); m1.scan_directory(in_dir)
       df1 = m1.build_csv_dataframe(in_dir)
       df1.to_csv(os.path.join(headers, "keys.csv"), index=False)
       prior = df1["AnonFrameOfReferenceUID"].unique()[0]
       print(f"Run 1 anon FOR: {prior}")
       m2 = DicomFileManager()
       m2.scan_directory(in_dir, seed_keys_csv=os.path.join(headers, "keys.csv"))
       resumed = m2.build_csv_dataframe(in_dir)["AnonFrameOfReferenceUID"].unique()[0]
       assert resumed == prior, "F3: seeded resume must reuse anon FOR"
       print(f"Run 2 (resume) anon FOR: {resumed}  (matches prior)")
       m2.scan_directory(in_dir)
       fresh = m2.build_csv_dataframe(in_dir)["AnonFrameOfReferenceUID"].unique()[0]
       assert fresh != prior, "F4: fresh re-scan must mint a NEW anon FOR"
       print(f"Run 3 (re-scan) anon FOR: {fresh}  (different - F4 reset OK)")
       print("PASS")
   finally:
       shutil.rmtree(tmp)
   PY
   ```
   Pass criteria: prints `PASS` on the last line; Run 2's anon FOR equals Run 1's; Run 3's anon FOR differs from Run 1's.

## Automated Tests

> Tests were not run locally as part of this fast PR. Reviewer should run the listed commands.

```bash
.venv/bin/pytest AnonymizeUltrasound/common/tests/ -q
.venv/bin/pytest AnonymizeUltrasound/tests/ -q
.venv/bin/pytest tests/ -q
```

The first command (198 tests) covers `test_uid_remap.py` (20 tests locking the SHA-256 / 2.25 arc / length / determinism properties), tests in `test_dicom_file_manager.py` covering UID remap, Anon CSV columns, TransducerData trimming, Manufacturer/ManufacturerModelName regression locks, the per-study run-local `FrameOfReferenceUID` policy (16 tests covering within-study sharing across series, cross-study isolation, cross-export unlinkability, cardinality invariant, intra-series sharing across SOP instances, coordinate-less branch, leakage guard, three-tier read-path plumbing, three resume scenarios via `keys.csv` seeding, keys.csv column persistence, and an end-to-end save->read round-trip), the `PatientAge` compute-from-`PatientBirthDate` path (11 tests covering year/month/day units, 90Y cap, source-PatientAge precedence, and missing/malformed/empty-input warning behavior, plus the new calendar-year boundary tests), and the `TestRedScaffolding` block covering the five review fixes; plus `test_dicom_processor.py` covering the sequence-info JSON SOP UID path.
